### PR TITLE
feat(flow): enforce bot-id assignment (RFC-090)

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -8,13 +8,14 @@ on:
         required: true
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve issue and Copilot bot ids
+      - name: Resolve issue and Copilot bot id
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -25,10 +26,14 @@ jobs:
           IID=$(gh issue view "$ISSUE" --repo "$REPO" --json id --jq .id)
           OWNER=${REPO%/*}; NAME=${REPO#*/}
           Q='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } } } } }'
-          BOT=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot"))) | .id' | head -n1)
-          if [ -z "$BOT" ]; then echo "No Copilot bot suggested for assignment"; exit 1; fi
+          BOT=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot"))) | .id' | head -n1 || true)
           CUR=$(gh issue view "$ISSUE" --repo "$REPO" --json assignees --jq '.assignees[].login' || true)
           if echo "$CUR" | grep -qi '^copilot$'; then echo "Already assigned"; exit 0; fi
+          if [ -z "$BOT" ]; then
+            echo "No Copilot bot in suggestedActors; attempting fallback via user(login:copilot-swe-agent)"
+            UID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
+            if [ -n "$UID" ]; then BOT="$UID"; else echo "No Copilot id resolved"; exit 1; fi
+          fi
           echo "Issue id: $IID | Copilot bot id: $BOT"
           echo "Assigning Copilot via replaceActorsForAssignable..."
           M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'

--- a/.github/workflows/assign-next-micro.yml
+++ b/.github/workflows/assign-next-micro.yml
@@ -1,3 +1,6 @@
+# NOTE: Deprecated alias. Prefer using the
+# `Assign Copilot to Issue` workflow (`assign-copilot-to-issue.yml`).
+# This remains for compatibility with older runbooks.
 name: assign-next-micro
 
 on:
@@ -8,13 +11,14 @@ on:
         required: true
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - name: Assign specific issue to Copilot via GraphQL
+      - name: Assign specific issue to Copilot via GraphQL (bot id)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -26,11 +30,15 @@ jobs:
           # Resolve Copilot bot id from suggestedActors
           OWNER=${REPO%/*}; NAME=${REPO#*/}
           Q='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } } } } }'
-          BOT=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot"))) | .id' | head -n1)
-          if [ -z "$BOT" ]; then echo "No Copilot bot suggested for assignment"; exit 1; fi
+          BOT=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot"))) | .id' | head -n1 || true)
           # If already assigned, skip
           CUR=$(gh issue view "$ISSUE" --repo "$REPO" --json assignees --jq '.assignees[].login' || true)
           if echo "$CUR" | grep -qi '^copilot$'; then echo "Already assigned"; exit 0; fi
+          if [ -z "$BOT" ]; then
+            echo "No Copilot bot in suggestedActors; attempting fallback via user(login:copilot-swe-agent)"
+            UID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
+            if [ -n "$UID" ]; then BOT="$UID"; else echo "No Copilot id resolved"; exit 1; fi
+          fi
           # Assign via replaceActorsForAssignable
           M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'
           gh api graphql -f query="$M" -F assignableId="$IID" -F actorIds="$BOT" >/dev/null

--- a/docs/flow-rfcs/README.md
+++ b/docs/flow-rfcs/README.md
@@ -6,3 +6,4 @@ Naming: `RFC-XXX-Title-Case-With-Dashes.md`
 
 Micro RFCs: create child issues as `RFC-XXX-YY` (YY = 2-digit micro index).
 
+See also: `docs/flow-rfcs/RFC-090-agent-flow-ops.md` for the Copilot agent flow operations guide.

--- a/docs/flow-rfcs/RFC-090-agent-flow-ops.md
+++ b/docs/flow-rfcs/RFC-090-agent-flow-ops.md
@@ -1,0 +1,78 @@
+# RFC-090: Agent Flow – Operations Guide
+
+Objective: Provide a quick-reference for operating and recovering the Game RFC Copilot flow.
+
+Scope: Workflows under `.github/workflows`, helper scripts under `.github/scripts`, and the micro-issue lifecycle. Keep changes scoped to flow; do not alter Tier 1 contracts.
+
+## Label Taxonomy (proposed)
+
+- type:test-failure: Test failures observed in CI.
+- type:infra: CI/workflow/script configuration issues.
+- type:flaky: Non-deterministic failures needing stabilization.
+- needs:repro: Needs reproduction steps or a minimal repro.
+- needs:owner: Awaiting human owner assignment.
+- flow:micro: Auto-generated micro issue from an RFC.
+- flow:watchdog: Recreated by watchdog following CI failure.
+- duplicate: Mark duplicates; link the canonical issue.
+
+Notes:
+- Prefer `type:*` for problem class, `needs:*` for next action, and `flow:*` for origin/context.
+- Add `rfc:NNN` label (optional) for manual triage by RFC number.
+
+## Core Workflows
+
+- generate-micro-issues: Parses an RFC MD and creates micro issues; assigns first to Copilot when available.
+- ci: Runs restore/build/test for PRs, and `copilot/**` branches.
+- ensure-closes-link: Appends `Closes #<issue>` to Copilot PR bodies when missing.
+- auto-ready-pr: Flips draft PR to ready after CI success; `/ready` comment also supported.
+- auto-approve-merge: Approves and enables auto-merge for Copilot PRs (env `copilot`).
+- auto-advance-micro: On PR merge, assigns the next micro issue to Copilot.
+- agent-watchdog: On CI failure, closes PR/branch, recreates the micro issue, and reassigns Copilot.
+- rfc-sync: On RFC MD changes, (re)generate micro issues and ensure the first is assigned.
+- rfc-dedupe: Nightly/manual dedupe of duplicate issues; links to canonical and cleans up.
+- assign-copilot-to-issue: Manual dispatch to assign a given issue to Copilot.
+
+Naming note: Prefer `assign-copilot-to-issue`. `assign-next-micro` remains as a compatibility alias for now.
+
+## Operator Commands (How-To)
+
+- Generate from an RFC: Actions → `generate-micro-issues` → inputs `rfc_path`, `assign_mode=bot`.
+- Manually assign: Actions → `assign-copilot-to-issue` → input `issue_number`.
+- Manually advance after merge: Actions → `auto-advance-micro` → input optional `pr_number`.
+- Recreate after failure: Actions → `rfc-dedupe` or let `agent-watchdog` auto-handle on `ci` failure.
+- Flip PR to ready: Comment `/ready` on the PR (or wait for `auto-ready-pr`).
+
+## Secrets and Permissions
+
+- GITHUB_TOKEN: Provided by Actions; must allow `issues: write`, `pull-requests: write` per workflow.
+- AUTO_APPROVE_TOKEN (optional): Environment `copilot`; used by `auto-approve-merge` to mitigate approval policy restrictions.
+
+## Health Checks
+
+1. Copilot bot presence: Repo `suggestedActors` must include a Copilot bot; otherwise assignment steps no-op.
+2. CI matrix: Dotnet 8.0 is configured; ensure build/test pass locally.
+3. Watchdog recycling: Confirm failed CI runs cause issue recreation; see workflow logs.
+4. Dedupe: Trigger `rfc-dedupe` manually to consolidate duplicates if needed.
+
+## Copilot Agent Identity
+
+- Bot login observed via GraphQL `suggestedActors`: typically `copilot-swe-agent` with `__typename: Bot`.
+- UI name appears as "Copilot"; assignment must use the Bot node `id` from GraphQL, not a username.
+- Verify with:
+  - `gh api graphql --raw-field query='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } } } } }' --raw-field owner='<owner>' --raw-field name='<repo>'`
+- All flows here assign using `replaceActorsForAssignable` and the Copilot Bot `id`.
+
+## Duplicates Handling
+
+- Let `rfc-dedupe` close obvious duplicates and link to canonical. For edge cases, add `duplicate` label manually and comment with `Closes #<canonical>` on the PR.
+- Avoid editing micro issue titles; the generator uses exact titles for idempotency.
+
+## Change Management
+
+- Keep changes scoped to flow; avoid renaming workflows unless also updating this doc and cross-references.
+- Prefer additive changes (new inputs/steps) over disruptive renames.
+
+## Appendix: Files of Interest
+
+- .github/workflows/*.yml
+- .github/scripts/*.py

--- a/docs/flow-rfcs/RFC-090-smoke-runbook.md
+++ b/docs/flow-rfcs/RFC-090-smoke-runbook.md
@@ -1,0 +1,46 @@
+# RFC-090: End-to-End Flow Smoke Test Runbook
+
+Purpose: Validate the Copilot agent flow from micro-issue generation → PR → CI → auto-ready → auto-merge → auto-advance.
+
+Pre-checks
+- Repo access: You are logged in via `gh auth status` with repo write.
+- Secrets: `AUTO_APPROVE_TOKEN` present in repo or environment `copilot` (verified earlier). `GITHUB_TOKEN` is provided by Actions.
+- CI: Local `dotnet build ./dotnet -warnaserror` and `dotnet test ./dotnet --no-build` succeed, or you intentionally test watchdog behavior.
+- Copilot bot: Repo environments show `copilot`; suggestedActors include a Copilot bot (assignment steps depend on it).
+
+Test Steps
+1) Generate micro issues from an RFC
+   - GitHub UI: Actions → `generate-micro-issues` → inputs:
+     - `rfc_path`: path under `docs/game-rfcs/` (e.g., `docs/game-rfcs/RFC-090-agent-flow-smoke-test.md`).
+     - `assign_mode`: `bot`.
+   - Expected: Workflow logs show created issues; first micro assigned to Copilot.
+
+2) Watch assignment and PR creation
+   - Copilot picks up the first micro, opens a draft PR on branch `copilot/rfc-XXX-YY-*`.
+   - `ensure-closes-link` appends `Closes #<issue>` to the PR body if missing.
+
+3) CI and ready-for-review
+   - `ci` runs restore/build/test for PR.
+   - On success, `auto-ready-pr` flips draft to ready. Alternatively, comment `/ready` on the PR.
+
+4) Approve and auto-merge
+   - `auto-approve-merge` approves the PR and enables squash auto-merge (requires repo setting Allow auto-merge).
+   - On merge, the branch is removed by GitHub (default), PR is closed.
+
+5) Auto-advance to next micro
+   - `auto-advance-micro` detects the merged PR and assigns the next micro issue to Copilot.
+   - Expected: The next `RFC-XXX-YY+1` issue becomes assigned to Copilot.
+
+6) Failure path (optional)
+   - Intentionally break a test or build to trigger `ci` failure.
+   - `agent-watchdog` reacts to the failed `ci` run: closes PR/branch, recreates the micro issue, labels as needed, reassigns Copilot.
+   - Expected: A fresh issue is created with a note referencing the failed run.
+
+Troubleshooting
+- No Copilot assignment: Ensure the Copilot bot shows up under `suggestedActors` and that the org/repo has Copilot enabled.
+- Auto-merge not enabled: Add `AUTO_APPROVE_TOKEN` or enable Actions approvals, and ensure repo Allows auto-merge.
+- Duplicates: Run `rfc-dedupe` from Actions to consolidate duplicate issues.
+
+Rollback / Cleanup
+- If a PR is stuck, comment `/ready` or close it; `agent-watchdog` will recycle on next failed `ci` or run `rfc-dedupe` to reconcile issues.
+


### PR DESCRIPTION
Links:
- RFC: docs/game-rfcs/RFC-090-agent-flow-smoke-test.md
- Playbook: docs/playbook/PLAYBOOK.md#pr-checklist

Acceptance Criteria:
- [x] Assign via GraphQL suggestedActors Bot id in workflows and scripts
- [x] Fallback to user(login: copilot-swe-agent) node id if Bot missing
- [x] Update rfc-sync to use assign-mode bot
- [x] Add operator docs: bot identity and smoke runbook
- [x] CI: dotnet build/test pass locally; workflows lint clean