### PR TITLE
fix(flow): avoid UID reserved var in assign workflows (RFC-090)

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -31,8 +31,8 @@ jobs:
           if echo "$CUR" | grep -qi '^copilot$'; then echo "Already assigned"; exit 0; fi
           if [ -z "$BOT" ]; then
             echo "No Copilot bot in suggestedActors; attempting fallback via user(login:copilot-swe-agent)"
-            UID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
-            if [ -n "$UID" ]; then BOT="$UID"; else echo "No Copilot id resolved"; exit 1; fi
+            COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
+            if [ -n "$COPILOT_ID" ]; then BOT="$COPILOT_ID"; else echo "No Copilot id resolved"; exit 1; fi
           fi
           echo "Issue id: $IID | Copilot bot id: $BOT"
           echo "Assigning Copilot via replaceActorsForAssignable..."

--- a/.github/workflows/assign-next-micro.yml
+++ b/.github/workflows/assign-next-micro.yml
@@ -36,8 +36,8 @@ jobs:
           if echo "$CUR" | grep -qi '^copilot$'; then echo "Already assigned"; exit 0; fi
           if [ -z "$BOT" ]; then
             echo "No Copilot bot in suggestedActors; attempting fallback via user(login:copilot-swe-agent)"
-            UID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
-            if [ -n "$UID" ]; then BOT="$UID"; else echo "No Copilot id resolved"; exit 1; fi
+            COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
+            if [ -n "$COPILOT_ID" ]; then BOT="$COPILOT_ID"; else echo "No Copilot id resolved"; exit 1; fi
           fi
           # Assign via replaceActorsForAssignable
           M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'


### PR DESCRIPTION
Replace UID with COPILOT_ID to avoid readonly var collision on Ubuntu runners.