### PR TITLE
fix(flow): assign via addAssigneesToAssignable using Copilot id (RFC-090)

### DIFF
--- a/.github/scripts/assign_first_open_for_rfc.py
+++ b/.github/scripts/assign_first_open_for_rfc.py
@@ -75,8 +75,8 @@ def main(argv:list[str]) -> int:
     if not iid:
         return 0
     if bot_id:
-        mut = 'mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId: $assignableId, actorIds: $actorIds }){ clientMutationId } }'
-        subprocess.run(['gh','api','graphql','-f',f'query={mut}','-F',f'assignableId={iid}','-F',f'actorIds={bot_id}'], check=False)
+        mut = 'mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId: $assignableId, assigneeIds: $assigneeIds }){ clientMutationId } }'
+        subprocess.run(['gh','api','graphql','-f',f'query={mut}','-F',f'assignableId={iid}','-F',f'assigneeIds={bot_id}'], check=False)
     else:
         print('no copilot bot id', file=sys.stderr)
     print(f'assigned #{sel_num} for RFC-{rfc}')

--- a/.github/scripts/assign_next_micro_issue.py
+++ b/.github/scripts/assign_next_micro_issue.py
@@ -62,7 +62,7 @@ def assign_issue_to_copilot(repo:str, issue:int)->bool:
             print('No Copilot id available to assign')
             return False
         issue_id = run_gh_json(['issue','view',str(issue),'--repo',repo,'--json','id']).get('id')
-        mut=f'''mutation{{ replaceActorsForAssignable(input:{{ assignableId:"{issue_id}", actorIds:["{bot['id']}"] }}){{ clientMutationId }} }}'''
+        mut=f'''mutation{{ addAssigneesToAssignable(input:{{ assignableId:"{issue_id}", assigneeIds:["{bot['id']}"] }}){{ clientMutationId }} }}'''
         _=subprocess.run(['gh','api','graphql','-f',f'query={mut}'], capture_output=True, text=True, check=True, env=env)
         print(f"Assigned issue #{issue} to Copilot (bot id {bot['id']})")
         return True

--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -35,7 +35,7 @@ jobs:
             if [ -n "$COPILOT_ID" ]; then BOT="$COPILOT_ID"; else echo "No Copilot id resolved"; exit 1; fi
           fi
           echo "Issue id: $IID | Copilot bot id: $BOT"
-          echo "Assigning Copilot via replaceActorsForAssignable..."
-          M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'
-          gh api graphql -f query="$M" -F assignableId="$IID" -F actorIds="$BOT" >/dev/null
+          echo "Assigning Copilot via addAssigneesToAssignable..."
+          M='mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId:$assignableId, assigneeIds:$assigneeIds }){ clientMutationId } }'
+          gh api graphql -f query="$M" -F assignableId="$IID" -F assigneeIds="$BOT" >/dev/null
           gh issue view "$ISSUE" --repo "$REPO" --json assignees,url

--- a/.github/workflows/assign-next-micro.yml
+++ b/.github/workflows/assign-next-micro.yml
@@ -39,8 +39,8 @@ jobs:
             COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
             if [ -n "$COPILOT_ID" ]; then BOT="$COPILOT_ID"; else echo "No Copilot id resolved"; exit 1; fi
           fi
-          # Assign via replaceActorsForAssignable
-          M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'
-          gh api graphql -f query="$M" -F assignableId="$IID" -F actorIds="$BOT" >/dev/null
+          # Assign via addAssigneesToAssignable
+          M='mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId:$assignableId, assigneeIds:$assigneeIds }){ clientMutationId } }'
+          gh api graphql -f query="$M" -F assignableId="$IID" -F assigneeIds="$BOT" >/dev/null
           gh issue view "$ISSUE" --repo "$REPO" --json assignees,url
 


### PR DESCRIPTION
Switch GraphQL mutation from replaceActorsForAssignable to addAssigneesToAssignable to ensure Copilot id assignment lands.

- Uses Bot id from suggestedActors; fallback to user(login: copilot-swe-agent) id
- Updates workflows and helper scripts
