### PR TITLE
fix(flow): require PAT for assignment and set environment copilot (RFC-090)

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   assign:
+    environment: copilot
     runs-on: ubuntu-latest
     steps:
       - name: Select token (prefer AUTO_APPROVE_TOKEN)
@@ -27,6 +28,21 @@ jobs:
             echo "GH_TOKEN=$GITHUB_TOKEN" >> $GITHUB_ENV
             echo "Using GITHUB_TOKEN"
           fi
+          # Enforce PAT usage as required
+          if [ -z "${AUTO_APPROVE_TOKEN:-}" ]; then
+            echo "ERROR: AUTO_APPROVE_TOKEN (PAT) is required for assignment. Configure it in repo or environment 'copilot'." >&2
+            exit 1
+          fi
+      - name: Debug suggestedActors (who is assignable)
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          OWNER=${REPO%/*}; NAME=${REPO#*/}
+          Q='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } ... on User { id } } } } }'
+          echo "Querying suggestedActors for $REPO"
+          gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes' || true
+
       - name: Resolve issue and Copilot bot id
         env:
           REPO: ${{ github.repository }}

--- a/.github/workflows/assign-next-micro.yml
+++ b/.github/workflows/assign-next-micro.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   assign:
+    environment: copilot
     runs-on: ubuntu-latest
     steps:
       - name: Select token (prefer AUTO_APPROVE_TOKEN)
@@ -30,6 +31,20 @@ jobs:
             echo "GH_TOKEN=$GITHUB_TOKEN" >> $GITHUB_ENV
             echo "Using GITHUB_TOKEN"
           fi
+          if [ -z "${AUTO_APPROVE_TOKEN:-}" ]; then
+            echo "ERROR: AUTO_APPROVE_TOKEN (PAT) is required for assignment. Configure it in repo or environment 'copilot'." >&2
+            exit 1
+          fi
+      - name: Debug suggestedActors (who is assignable)
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          OWNER=${REPO%/*}; NAME=${REPO#*/}
+          Q='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } ... on User { id } } } } }'
+          echo "Querying suggestedActors for $REPO"
+          gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes' || true
+
       - name: Assign specific issue to Copilot via GraphQL (bot id)
         env:
           REPO: ${{ github.repository }}

--- a/.github/workflows/auto-advance-micro.yml
+++ b/.github/workflows/auto-advance-micro.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   advance:
+    environment: copilot
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     permissions:
@@ -26,11 +27,23 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Select token (prefer AUTO_APPROVE_TOKEN)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTO_APPROVE_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
+        run: |
+          if [ -n "${AUTO_APPROVE_TOKEN:-}" ]; then
+            echo "GH_TOKEN=$AUTO_APPROVE_TOKEN" >> $GITHUB_ENV
+            echo "Using AUTO_APPROVE_TOKEN"
+          else
+            echo "ERROR: AUTO_APPROVE_TOKEN (PAT) is required for assignment in auto-advance." >&2
+            exit 1
+          fi
+
       - name: Assign next micro-issue to Copilot
         env:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           ASSIGN: '1'
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python .github/scripts/assign_next_micro_issue.py --assign

--- a/.github/workflows/rfc-sync.yml
+++ b/.github/workflows/rfc-sync.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   generate_and_assign:
+    environment: copilot
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,8 +41,6 @@ jobs:
 
       - name: Generate micro issues for each changed RFC
         if: steps.changed.outputs.files != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IFS=',' read -r -a FILES <<< "${{ steps.changed.outputs.files }}"
           for f in "${FILES[@]}"; do
@@ -53,10 +52,22 @@ jobs:
               --assign-mode bot || true
           done
 
+      - name: Select token (prefer AUTO_APPROVE_TOKEN)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTO_APPROVE_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
+        run: |
+          if [ -n "${AUTO_APPROVE_TOKEN:-}" ]; then
+            echo "GH_TOKEN=$AUTO_APPROVE_TOKEN" >> $GITHUB_ENV
+            echo "Using AUTO_APPROVE_TOKEN"
+          else
+            echo "ERROR: AUTO_APPROVE_TOKEN (PAT) is required for assignment in rfc-sync." >&2
+            exit 1
+          fi
+
       - name: Ensure first open micro is assigned to Copilot
         if: steps.changed.outputs.files != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Use AUTO_APPROVE_TOKEN (PAT) for all assignment paths (assign-copilot-to-issue, assign-next-micro, auto-advance-micro, rfc-sync). Fail fast if PAT is missing. Add environment: copilot so env-scoped secrets are available.