### PR TITLE
fix(flow): use replaceActors for Bot ids and addAssignees for User ids (RFC-090)

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Querying suggestedActors for $REPO"
           gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes' || true
 
-      - name: Resolve issue and Copilot bot id
+      - name: Resolve issue and Copilot actor
         env:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.inputs.issue_number }}
@@ -53,10 +53,12 @@ jobs:
           IID=$(gh issue view "$ISSUE" --repo "$REPO" --json id --jq .id)
           OWNER=${REPO%/*}; NAME=${REPO#*/}
           Q='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } } } } }'
-          BOT=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot"))) | .id' | head -n1 || true)
+          NODE=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot")))' | head -n1 || true)
+          ACTOR_ID=$(jq -r 'select(.) | .id // empty' <<<"$NODE" || true)
+          ACTOR_TYPE=$(jq -r 'select(.) | .__typename // empty' <<<"$NODE" || true)
           CUR=$(gh issue view "$ISSUE" --repo "$REPO" --json assignees --jq '.assignees[].login' || true)
           if echo "$CUR" | grep -qi '^copilot$'; then echo "Already assigned"; exit 0; fi
-          if [ -z "$BOT" ]; then
+          if [ -z "${ACTOR_ID:-}" ]; then
             echo "No Copilot bot in suggestedActors; attempting fallback via user(login:Copilot)"
             COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='Copilot' --jq '.data.user.id' || true)
             # Guard against error JSON leaking into COPILOT_ID
@@ -66,10 +68,16 @@ jobs:
               COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
               if echo "$COPILOT_ID" | grep -q '{'; then COPILOT_ID=""; fi
             fi
-            if [ -n "$COPILOT_ID" ]; then BOT="$COPILOT_ID"; else echo "No Copilot id resolved"; exit 1; fi
+            if [ -n "$COPILOT_ID" ]; then ACTOR_ID="$COPILOT_ID"; ACTOR_TYPE="User"; else echo "No Copilot id resolved"; exit 1; fi
           fi
-          echo "Issue id: $IID | Copilot bot id: $BOT"
-          echo "Assigning Copilot via addAssigneesToAssignable..."
-          M='mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId:$assignableId, assigneeIds:$assigneeIds }){ clientMutationId } }'
-          gh api graphql -f query="$M" -F assignableId="$IID" -F assigneeIds="$BOT" >/dev/null
+          echo "Issue id: $IID | Copilot actor id: $ACTOR_ID type: $ACTOR_TYPE"
+          if [ "$ACTOR_TYPE" = "Bot" ]; then
+            echo "Assigning via replaceActorsForAssignable (Bot)"
+            M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'
+            gh api graphql -f query="$M" -F assignableId="$IID" -F actorIds="$ACTOR_ID" >/dev/null
+          else
+            echo "Assigning via addAssigneesToAssignable (User)"
+            M='mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId:$assignableId, assigneeIds:$assigneeIds }){ clientMutationId } }'
+            gh api graphql -f query="$M" -F assignableId="$IID" -F assigneeIds="$ACTOR_ID" >/dev/null
+          fi
           gh issue view "$ISSUE" --repo "$REPO" --json assignees,url

--- a/.github/workflows/assign-next-micro.yml
+++ b/.github/workflows/assign-next-micro.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Querying suggestedActors for $REPO"
           gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes' || true
 
-      - name: Assign specific issue to Copilot via GraphQL (bot id)
+      - name: Assign specific issue to Copilot via GraphQL (bot/user id)
         env:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.inputs.issue_number }}
@@ -56,11 +56,13 @@ jobs:
           # Resolve Copilot bot id from suggestedActors
           OWNER=${REPO%/*}; NAME=${REPO#*/}
           Q='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){ nodes{ login __typename ... on Bot { id } } } } }'
-          BOT=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot"))) | .id' | head -n1 || true)
+          NODE=$(gh api graphql -f query="$Q" -F owner="$OWNER" -F name="$NAME" --jq '.data.repository.suggestedActors.nodes[] | select(."__typename"=="Bot" and (.login|ascii_downcase|test("copilot")))' | head -n1 || true)
+          ACTOR_ID=$(jq -r 'select(.) | .id // empty' <<<"$NODE" || true)
+          ACTOR_TYPE=$(jq -r 'select(.) | .__typename // empty' <<<"$NODE" || true)
           # If already assigned, skip
           CUR=$(gh issue view "$ISSUE" --repo "$REPO" --json assignees --jq '.assignees[].login' || true)
           if echo "$CUR" | grep -qi '^copilot$'; then echo "Already assigned"; exit 0; fi
-          if [ -z "$BOT" ]; then
+          if [ -z "${ACTOR_ID:-}" ]; then
             echo "No Copilot bot in suggestedActors; attempting fallback via user(login:Copilot) then copilot-swe-agent"
             COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='Copilot' --jq '.data.user.id' || true)
             if echo "$COPILOT_ID" | grep -q '{'; then COPILOT_ID=""; fi
@@ -68,10 +70,15 @@ jobs:
               COPILOT_ID=$(gh api graphql -f query='query($login:String!){ user(login:$login){ id __typename } }' -F login='copilot-swe-agent' --jq '.data.user.id' || true)
               if echo "$COPILOT_ID" | grep -q '{'; then COPILOT_ID=""; fi
             fi
-            if [ -n "$COPILOT_ID" ]; then BOT="$COPILOT_ID"; else echo "No Copilot id resolved"; exit 1; fi
+            if [ -n "$COPILOT_ID" ]; then ACTOR_ID="$COPILOT_ID"; ACTOR_TYPE="User"; else echo "No Copilot id resolved"; exit 1; fi
           fi
-          # Assign via addAssigneesToAssignable
-          M='mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId:$assignableId, assigneeIds:$assigneeIds }){ clientMutationId } }'
-          gh api graphql -f query="$M" -F assignableId="$IID" -F assigneeIds="$BOT" >/dev/null
+          # Assign via appropriate mutation
+          if [ "$ACTOR_TYPE" = "Bot" ]; then
+            M='mutation($assignableId: ID!, $actorIds: [ID!]!){ replaceActorsForAssignable(input:{ assignableId:$assignableId, actorIds:$actorIds }){ clientMutationId } }'
+            gh api graphql -f query="$M" -F assignableId="$IID" -F actorIds="$ACTOR_ID" >/dev/null
+          else
+            M='mutation($assignableId: ID!, $assigneeIds: [ID!]!){ addAssigneesToAssignable(input:{ assignableId:$assignableId, assigneeIds:$assigneeIds }){ clientMutationId } }'
+            gh api graphql -f query="$M" -F assignableId="$IID" -F assigneeIds="$ACTOR_ID" >/dev/null
+          fi
           gh issue view "$ISSUE" --repo "$REPO" --json assignees,url
 


### PR DESCRIPTION
Assignment now selects mutation based on actor type: Bot -> replaceActorsForAssignable; User -> addAssigneesToAssignable. This follows the official docs expectation for the Copilot Coding Agent bot id.