### PR TITLE
feat(docs): create RFC-093-01 recovery placeholder

### DIFF
--- a/docs/game-rfc-test-93/PLACEHOLDER.md
+++ b/docs/game-rfc-test-93/PLACEHOLDER.md
@@ -1,1 +1,3 @@
-retry-93
+ok-93
+
+Reference: RFC-093 Agent Flow Recovery


### PR DESCRIPTION
Add \docs/game-rfc-test-93/PLACEHOLDER.md\ with a one-line \ok-93\ and an RFC reference.

## Changes
- Updated \docs/game-rfc-test-93/PLACEHOLDER.md\ with 'ok-93' and RFC reference
- Part of RFC-093 Agent Flow Recovery micro issue 01

## Acceptance Criteria
- [x] Add \docs/game-rfc-test-93/PLACEHOLDER.md\ with a one-line \ok-93\ and an RFC reference
- [x] Build passes
- [x] PR title follows Conventional Commits

Closes #83