### PR TITLE
chore(projects): limit pr status workflow triggers

### DIFF
--- a/.github/workflows/update-project-status-on-pr.yml
+++ b/.github/workflows/update-project-status-on-pr.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, closed]
   workflow_run:
-    workflows: ["*"]
-    types: [requested, completed]
+    workflows: ["ci"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -85,16 +85,13 @@ jobs:
                   linkedIssues.push(parseInt(match[1]));
                 }
 
-                if (action === 'requested') {
-                  targetStatus = 'In progress';
-                  console.log(`⚡ Workflow started → Moving linked issues to "In progress"`);
-                } else if (action === 'completed' && workflow.conclusion === 'success') {
-                  targetStatus = 'In review';
-                  console.log(`✅ Workflow completed successfully → Moving linked issues to "In review"`);
-                } else {
-                  console.log('ℹ️ No status change needed for this workflow action');
+                if (workflow.conclusion !== 'success') {
+                  console.log(`ℹ️ Workflow conclusion "${workflow.conclusion}" is not "success", skipping status update`);
                   return;
                 }
+
+                targetStatus = 'In review';
+                console.log(`✅ Workflow completed successfully → Moving linked issues to "In review"`);
               } else {
                 console.log('ℹ️ No linked PRs found for this workflow run');
                 return;


### PR DESCRIPTION
## Summary
- limit Project V2 status updater to the main CI workflow finishing successfully
- avoid redundant workflow_run requested events that were triggering extra runner minutes

## Testing
- no tests (workflow-only change)

## RFC Link
- [Flow-RFC-013 workflow consolidation and simplification](https://github.com/ApprenticeGC/ithome-ironman-2025/blob/main/docs/flow-rfcs/Flow-RFC-013-workflow-consolidation-and-simplification.md)

## Checklist
- [x] Linked RFC above
- [x] Referenced docs/playbook/PLAYBOOK.md#pr-checklist
- [x] Acceptance criteria met
- [x] `dotnet build ./dotnet -warnaserror` *(N/A: workflow-only change)*
- [x] `dotnet test ./dotnet --no-build` *(N/A: workflow-only change)*\nSee docs/playbook/PLAYBOOK.md#pr-checklist for full process guidance.\n