### PR TITLE
fix(ci): guard dispatch against missing refs

### DIFF
--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -16,10 +16,76 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target ref
+        id: resolve_ref
+        shell: bash
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ref="${TARGET_REF//$'\r'/}"
+          ref="${ref//$'\n'/}"
+          if [[ -z "$ref" ]]; then
+            echo "::error::target_ref input is empty"
+            exit 1
+          fi
+
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+
+          declare -a candidates=("$ref")
+          if [[ "$ref" == refs/* ]]; then
+            heads="${ref#refs/heads/}"
+            tags="${ref#refs/tags/}"
+            if [[ "$heads" != "$ref" ]]; then
+              candidates+=("$heads")
+            fi
+            if [[ "$tags" != "$ref" ]]; then
+              candidates+=("$tags")
+            fi
+          else
+            candidates+=("refs/heads/$ref" "refs/tags/$ref")
+          fi
+
+          sha=""
+          resolved=""
+
+          for candidate in "${candidates[@]}"; do
+            [[ -z "$candidate" ]] && continue
+            result=$(gh api graphql \
+              -F owner="$owner" \
+              -F name="$repo" \
+              -F expression="$candidate" \
+              -f query='query($owner:String!,$name:String!,$expression:String!){repository(owner:$owner,name:$name){object(expression:$expression){... on Commit { oid }}}}' \
+              --jq '.data.repository.object.oid // empty' 2>/dev/null)
+            if [[ -n "$result" ]]; then
+              sha="$result"
+              resolved="$candidate"
+              break
+            fi
+          done
+
+          if [[ -z "$sha" && "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+            sha="$ref"
+            resolved="$ref"
+          fi
+
+          if [[ -z "$sha" ]]; then
+            echo "::error::Unable to resolve target_ref '$ref' to a commit in $GITHUB_REPOSITORY." >&2
+            echo "Candidates attempted: ${candidates[*]}" >&2
+            exit 1
+          fi
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "resolved_ref=$resolved" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved $ref to commit $sha (via $resolved)"
+
       - name: Checkout target ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.target_ref }}
+          ref: ${{ steps.resolve_ref.outputs.checkout_ref }}
 
       - name: Resolve target commit SHA
         id: sha
@@ -40,7 +106,7 @@ jobs:
         run: dotnet test ./dotnet --no-build --verbosity normal
 
       - name: Set commit status (success)
-        if: success()
+        if: success() && steps.sha.outputs.sha != ""
         env:
           SHA: ${{ steps.sha.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +118,7 @@ jobs:
             -f description="ci-dispatch passed"
 
       - name: Set commit status (failure)
-        if: failure()
+        if: failure() && steps.sha.outputs.sha != ""
         env:
           SHA: ${{ steps.sha.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- resolve the `target_ref` input to a commit before checkout so missing branches fail fast
- avoid posting status updates when no commit SHA was resolved

## Testing
- no tests (workflow-only change)

## RFC Link
- [Flow-RFC-013 workflow consolidation and simplification](https://github.com/ApprenticeGC/ithome-ironman-2025/blob/main/docs/flow-rfcs/Flow-RFC-013-workflow-consolidation-and-simplification.md)

## Checklist
- [x] Linked RFC above
- [x] Referenced docs/playbook/PLAYBOOK.md#pr-checklist
- [x] Acceptance criteria met
- [x] `dotnet build ./dotnet -warnaserror` *(N/A: workflow-only change)*
- [x] `dotnet test ./dotnet --no-build` *(N/A: workflow-only change)*\nSee docs/playbook/PLAYBOOK.md#pr-checklist for full process guidance.\n