### PR TITLE
feat(flow): add chain health scan and assignment mutex

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -34,6 +34,16 @@ jobs:
             exit 1
           fi
 
+      - name: Acquire RFC series lock
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER=${{ github.repository_owner }}
+          REPO_NAME=${{ github.event.repository.name }}
+          python3 scripts/python/production/rfc_assignment_mutex.py \
+            --owner "$OWNER" \
+            --repo "$REPO_NAME" \
+            --issue-number ${{ github.event.inputs.issue_number }}
       - name: Assign issue to Copilot
         env:
           GH_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chain-health-scan.yml
+++ b/.github/workflows/chain-health-scan.yml
@@ -1,0 +1,52 @@
+name: chain-health-scan
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+    inputs:
+      destructive:
+        description: "Execute destructive remediation (not yet available)"
+        required: false
+        type: boolean
+      max_runs:
+        description: "Maximum workflow runs to inspect"
+        required: false
+        default: "200"
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CHAIN_MAX_RUNS: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.max_runs) || '200' }}
+      CHAIN_DESTRUCTIVE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.destructive) || 'false' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate chain consistency plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmd=(python scripts/python/production/chain_consistency_manager.py
+               --repo "${{ github.repository }}"
+               --output chain_reset_plan.json
+               --max-runs "${CHAIN_MAX_RUNS}")
+          if [ "${CHAIN_DESTRUCTIVE}" = "true" ]; then
+            cmd+=("--destructive")
+          fi
+          "${cmd[@]}"
+
+      - name: Upload chain plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chain-consistency-plan
+          path: chain_reset_plan.json

--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -16,10 +16,76 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target ref
+        id: resolve_ref
+        shell: bash
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ref="${TARGET_REF//$'\r'/}"
+          ref="${ref//$'\n'/}"
+          if [[ -z "$ref" ]]; then
+            echo "::error::target_ref input is empty"
+            exit 1
+          fi
+
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+
+          declare -a candidates=("$ref")
+          if [[ "$ref" == refs/* ]]; then
+            heads="${ref#refs/heads/}"
+            tags="${ref#refs/tags/}"
+            if [[ "$heads" != "$ref" ]]; then
+              candidates+=("$heads")
+            fi
+            if [[ "$tags" != "$ref" ]]; then
+              candidates+=("$tags")
+            fi
+          else
+            candidates+=("refs/heads/$ref" "refs/tags/$ref")
+          fi
+
+          sha=""
+          resolved=""
+
+          for candidate in "${candidates[@]}"; do
+            [[ -z "$candidate" ]] && continue
+            result=$(gh api graphql \
+              -F owner="$owner" \
+              -F name="$repo" \
+              -F expression="$candidate" \
+              -f query='query($owner:String!,$name:String!,$expression:String!){repository(owner:$owner,name:$name){object(expression:$expression){... on Commit { oid }}}}' \
+              --jq '.data.repository.object.oid // empty' 2>/dev/null)
+            if [[ -n "$result" ]]; then
+              sha="$result"
+              resolved="$candidate"
+              break
+            fi
+          done
+
+          if [[ -z "$sha" && "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+            sha="$ref"
+            resolved="$ref"
+          fi
+
+          if [[ -z "$sha" ]]; then
+            echo "::error::Unable to resolve target_ref '$ref' to a commit in $GITHUB_REPOSITORY." >&2
+            echo "Candidates attempted: ${candidates[*]}" >&2
+            exit 1
+          fi
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "resolved_ref=$resolved" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$sha" >> "$GITHUB_OUTPUT"
+          echo "Resolved $ref to commit $sha (via $resolved)"
+
       - name: Checkout target ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.target_ref }}
+          ref: ${{ steps.resolve_ref.outputs.checkout_ref }}
 
       - name: Resolve target commit SHA
         id: sha
@@ -40,7 +106,7 @@ jobs:
         run: dotnet test ./dotnet --no-build --verbosity normal
 
       - name: Set commit status (success)
-        if: success()
+        if: success() && steps.sha.outputs.sha != ""
         env:
           SHA: ${{ steps.sha.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +118,7 @@ jobs:
             -f description="ci-dispatch passed"
 
       - name: Set commit status (failure)
-        if: failure()
+        if: failure() && steps.sha.outputs.sha != ""
         env:
           SHA: ${{ steps.sha.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/flow-rfcs/Flow-RFC-008-chain-consistency-and-atomic-reset.md
+++ b/docs/flow-rfcs/Flow-RFC-008-chain-consistency-and-atomic-reset.md
@@ -1,0 +1,96 @@
+# Flow-RFC-008: Chain Consistency and Atomic Reset (Issue → PR → CI Runner → Branch)
+
+## Status
+In Progress (detection tooling merged 2025-09-19)
+
+## Problem
+Automation treats Issue, PR, CI runs, and branch as a logical chain. Failures (merge conflict, abandoned PR, missing branch, stuck CI) must trigger atomic teardown + recreation. Current implementation misses some edge cases:
+- PR closed due to merge conflict or manual close leaves issue assigned and branch orphaned.
+- Stale branches without open PR exist.
+- Chains partially cleaned causing duplicate future attempts.
+
+## Goals
+- Deterministic detection of broken chain states
+- Single atomic cleanup action (issue close or recreate, PR close/delete branch, cancel CI if running)
+- Recreation logic only after successful cleanup preconditions verified
+- Safety: never destroy unrelated branches or issues
+
+## Chain Definition
+`ChainID = RFC Series + Micro Number` (parsed from issue/PR title). All artifacts referencing that identifier are members.
+
+## Broken State Conditions
+| Code | Detection | Example |
+|------|-----------|---------|
+| BRANCH_ONLY | Branch exists, no PR, issue closed | leftover `copilot/rfc-093-02` |
+| ISSUE_ONLY_ASSIGNED | Issue assigned, no PR after T threshold (e.g., 15m) | assignment stalled |
+| PR_CLOSED_CONFLICT | PR closed with reason merge conflict | GitHub event webhook data |
+| CI_STUCK | Last CI run > 30m pending | workflow dispatch hung |
+| DUPLICATE_PRS | >1 open PR for same chain ID | race condition |
+
+## Cleanup Algorithm (Pseudo)
+```
+identify all chain IDs (scan issues + PRs)
+for each chain:
+  classify state
+  if healthy: continue
+  log planned action
+  if destructive mode enabled:
+     cancel active workflows
+     close PRs (comment with reason)
+     delete branches (if pattern matches + merged status verified)
+     close or recreate issue depending on policy
+  if recreate_needed:
+     create fresh issue (copy original body + increment revival counter)
+     (optional) assign bot
+```
+
+## Recreation Policy
+| Condition | Action |
+|-----------|--------|
+| PR_CLOSED_CONFLICT | Close PR, delete branch, reopen issue OR create new issue with suffix `-R1` |
+| BRANCH_ONLY | Delete branch (safe heuristic: branch starts `copilot/`) |
+| ISSUE_ONLY_ASSIGNED | Unassign (if possible) or close + recreate |
+| DUPLICATE_PRS | Keep lowest PR number; close others + recreate their issues unassigned |
+
+## Safety Mechanisms
+- Dry-run mode prints JSON plan `chain_reset_plan.json`.
+- Require env var `CHAIN_RESET_CONFIRM=1` to execute destructive phase in workflow.
+- Branch deletion whitelist: regex `^(copilot|automation|bot)/`.
+- Minimum age check (e.g., >5 min since creation) before automatic reset.
+
+## Observability
+- Emit metrics: `chains_total`, `chains_broken`, `chains_recreated`, `recreate_reason_counts`.
+- Append machine-readable log `chain_actions.log` (JSON lines).
+
+## Implementation Components
+1. New script `chain_consistency_manager.py`.
+2. Shared parsing utility for RFC identifiers (reusable by monitors).
+3. Workflow `chain-health-scan.yml` (cron every 10m).
+4. Optional manual `workflow_dispatch` with `destructive: true` input.
+
+## Test Plan
+- Synthetic fixtures: simulate each state class (mock GitHub API responses).
+- End-to-end dry-run against current repo (should produce zero destructive actions initially).
+- Induced conflict scenario via test branch rebase.
+
+## Risks & Mitigations
+| Risk | Mitigation |
+|------|------------|
+| Accidental deletion of user branch | strict naming + merged check + dry-run confirm |
+| Flapping (recreate loop) | add `max_recreate_attempts` recorded in issue body hidden marker |
+| API rate limits | batch queries (GraphQL) |
+
+## Acceptance Criteria
+- All five broken states classified correctly in tests
+- Zero false positives on healthy chains across 50 sample evaluations
+- Conflict-closed PR leads to clean recreation within one scan cycle
+
+## Rollout
+Phase 1: detection only (dry-run) → Phase 2: enable selective actions (conflict cases) → Phase 3: full automation.
+
+## Implementation (Phase 1)
+- Detection + planning script: `scripts/python/production/chain_consistency_manager.py` generates machine-readable remediation plans covering branch-only, issue-only-assigned, conflict-closed PRs, stuck CI runs, and duplicate PRs.
+- Scheduled workflow: `.github/workflows/chain-health-scan.yml` runs every 10 minutes (and via `workflow_dispatch`) to publish `chain_reset_plan.json` artifacts.
+- Unit coverage added under `scripts/python/tests/automation/test_chain_consistency.py` for identifier parsing and broken-state classification.
+
+**Outstanding (Phase 2)**: implement `--destructive` cleanup actions (branch deletion, PR closure, issue recreation) with guard rails once the dry-run results are validated.

--- a/docs/flow-rfcs/Flow-RFC-009-assignment-mutex-and-race-prevention.md
+++ b/docs/flow-rfcs/Flow-RFC-009-assignment-mutex-and-race-prevention.md
@@ -1,0 +1,88 @@
+# Flow-RFC-009: Assignment Mutex and Race Prevention
+
+## Status
+In Progress (series lock enforcement merged 2025-09-19)
+
+## Problem
+Multiple issues in the same RFC series must not be simultaneously assigned to the automation bot. Current cron assignment logic reduces but does not eliminate race: concurrent workflow executions or manual + cron overlap can assign more than one micro issue.
+
+## Goals
+- Enforce SINGLE active assigned issue per RFC series
+- Prevent concurrent assignment operations from conflicting
+- Provide clear queueing for next issue candidates
+
+## Non-Goals
+- Reordering micro issue priorities based on complexity
+
+## Design Overview
+Introduce distributed soft-lock mechanism + pre-assignment validation.
+
+### Lock Representation
+- New GitHub issue label: `rfc-series-active:RFC-XYZ`
+- Or alternative: dedicated hidden tracking issue (one per series) containing JSON state.
+Chosen approach: **Tracking issue per RFC series** named: `RFC-XYZ Series State`.
+
+### State Document Structure (in body fenced JSON)
+```json
+{
+  "series": "RFC-093",
+  "active_issue": 123,
+  "queue": [124, 125],
+  "updated_at": "2025-09-19T03:15:22Z",
+  "version": 1
+}
+```
+
+### Assignment Algorithm
+```
+resolve series from candidate issue title
+fetch tracking issue (create if missing)
+parse JSON; validate version
+if active_issue open & assigned: abort (idempotent no-op)
+set active_issue = candidate issue number; remove from queue if present
+patch tracking issue body (ETag conditional update to avoid lost update)
+assign bot
+```
+
+### Concurrency Control
+- Use conditional update via `If-Match` header on issue update (GitHub REST ETag) or optimistic retry loop (max 5 tries).
+- Add backoff jitter 200–800ms between retries.
+
+### Queue Management
+Unassigned issues discovered when scanning series get appended (dedupe). When active issue completes (closed by merged PR), next queue head is promoted by cron job.
+
+### Failure Handling
+- If active issue closed but PR not merged (abandoned), mark `active_issue=null` and promote next.
+- If tracking issue missing or corrupted, rebuild from live issues (regenerate queue sorted by micro number).
+
+## Observability
+- Metrics JSON artifact: `assignment_mutex_metrics.json` with `promotion_events`, `duplicate_prevented`, `retries`, `conflicts`.
+- Optional comment on tracking issue summarizing last promotion.
+
+## Test Plan
+Unit: parsing + queue operations, optimistic concurrency retries.
+Integration: simulate two concurrent assignment attempts (pytest + threading or two processes) verifying only one success.
+Recovery: corrupt tracking body → rebuild logic test.
+
+## Risks & Mitigations
+| Risk | Mitigation |
+|------|------------|
+| Tracking issue deleted | Recreate via discovery (label scan) |
+| JSON corruption | Validate schema; fallback rebuild |
+| Race still slips through | Optimistic loop + short cron interval (< conflict window) |
+
+## Acceptance Criteria
+- Zero double-assignment in 100 simulated concurrent attempts
+- Active issue always reflects reality within one cron cycle
+
+## Rollout
+Phase 1: tracking issue generation + read-only metrics
+Phase 2: enforce single assignment
+Phase 3: integrate promotion events posting status comments.
+
+## Implementation (Phase 1)
+- Added `scripts/python/production/rfc_assignment_mutex.py` to manage per-series tracking issues and enforce single active issue assignment.
+- Updated `assign-copilot-to-issue.yml` to acquire the lock before calling Copilot; the step aborts with `queued` status if another issue is active.
+- State documents stored in `RFC-XYZ Series State` tracking issues include queued issue numbers for observability.
+
+**Outstanding**: add automatic promotion/release hooks post-merge, optimistic concurrency via ETag, and queue-based auto-assignment in cron automation.

--- a/scripts/python/production/chain_consistency_manager.py
+++ b/scripts/python/production/chain_consistency_manager.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""
+Chain consistency manager per Flow-RFC-008.
+
+Phase 1 implementation focuses on detection and dry-run planning:
+- Identify chains (issue/PR/branch/CI groupings) by RFC identifier (e.g., RFC-093-02)
+- Detect broken chain states (branch-only, issue-only-assigned, closed-conflict PRs,
+  stuck CI runs, duplicate PRs)
+- Emit a machine-readable plan describing remediation actions (no destructive operations yet)
+
+Usage:
+    python chain_consistency_manager.py --repo ApprenticeGC/ithome-ironman-2025
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urlencode
+
+STATE_BRANCH_ONLY = "BRANCH_ONLY"
+STATE_ISSUE_ONLY_ASSIGNED = "ISSUE_ONLY_ASSIGNED"
+STATE_PR_CLOSED_CONFLICT = "PR_CLOSED_CONFLICT"
+STATE_CI_STUCK = "CI_STUCK"
+STATE_DUPLICATE_PRS = "DUPLICATE_PRS"
+KNOWN_STATES = {
+    STATE_BRANCH_ONLY,
+    STATE_ISSUE_ONLY_ASSIGNED,
+    STATE_PR_CLOSED_CONFLICT,
+    STATE_CI_STUCK,
+    STATE_DUPLICATE_PRS,
+}
+
+CHAIN_PATTERN = re.compile(r"(?:Game-)?RFC-(\d{1,4})-(\d{1,3})", re.IGNORECASE)
+BRANCH_PATTERN = re.compile(r"(?:copilot|automation|bot)/rfc-(\d{1,4})-(\d{1,3})", re.IGNORECASE)
+CI_STUCK_THRESHOLD_MINUTES = 30
+
+
+class ChainConsistencyError(RuntimeError):
+    """Raised for fatal errors in the chain consistency manager."""
+
+
+@dataclass
+class IssueInfo:
+    number: int
+    title: str
+    state: str
+    assignees: List[str]
+    url: str
+    updated_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "state": self.state,
+            "assignees": self.assignees,
+            "url": self.url,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class PullInfo:
+    number: int
+    title: str
+    state: str
+    merged: bool
+    draft: bool
+    head_ref: str
+    source_branch: str
+    url: str
+    updated_at: Optional[str] = None
+    closed_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "state": self.state,
+            "merged": self.merged,
+            "draft": self.draft,
+            "head_ref": self.head_ref,
+            "source_branch": self.source_branch,
+            "url": self.url,
+            "updated_at": self.updated_at,
+            "closed_at": self.closed_at,
+        }
+
+
+@dataclass
+class BranchInfo:
+    name: str
+    protected: bool
+    url: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "protected": self.protected,
+            "url": self.url,
+        }
+
+
+@dataclass
+class RunInfo:
+    run_id: int
+    workflow_name: str
+    head_branch: str
+    status: str
+    conclusion: Optional[str]
+    created_at: str
+    url: str
+
+    def age_minutes(self, reference: datetime) -> float:
+        created = parse_github_timestamp(self.created_at)
+        return (reference - created).total_seconds() / 60.0
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "workflow_name": self.workflow_name,
+            "head_branch": self.head_branch,
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "created_at": self.created_at,
+            "url": self.url,
+        }
+
+
+@dataclass
+class ChainRecord:
+    chain_id: str
+    issues: List[IssueInfo] = field(default_factory=list)
+    pull_requests: List[PullInfo] = field(default_factory=list)
+    branches: List[BranchInfo] = field(default_factory=list)
+    runs: List[RunInfo] = field(default_factory=list)
+
+    def detect_states(self, *, now: datetime) -> List[str]:
+        states: List[str] = []
+        open_prs = [pr for pr in self.pull_requests if pr.state.lower() == "open"]
+        closed_prs = [pr for pr in self.pull_requests if pr.state.lower() == "closed" and not pr.merged]
+        branches_present = len(self.branches) > 0
+        open_issues = [iss for iss in self.issues if iss.state.lower() == "open"]
+        open_issue_assigned = any(issue.assignees for issue in open_issues)
+        closed_issues = [iss for iss in self.issues if iss.state.lower() == "closed"]
+
+        if branches_present and not open_prs and not open_issues and closed_issues:
+            states.append(STATE_BRANCH_ONLY)
+
+        if open_issue_assigned and not open_prs and not branches_present:
+            states.append(STATE_ISSUE_ONLY_ASSIGNED)
+
+        if closed_prs:
+            states.append(STATE_PR_CLOSED_CONFLICT)
+
+        stuck_runs = [
+            run
+            for run in self.runs
+            if run.status in {"in_progress", "queued"} and run.age_minutes(now) > CI_STUCK_THRESHOLD_MINUTES
+        ]
+        if stuck_runs:
+            states.append(STATE_CI_STUCK)
+
+        if len(open_prs) > 1:
+            states.append(STATE_DUPLICATE_PRS)
+
+        return states
+
+    def recommended_actions(self, states: Iterable[str]) -> List[str]:
+        actions: List[str] = []
+        for state in states:
+            actions.extend(RECOMMENDATIONS.get(state, []))
+        seen = set()
+        unique: List[str] = []
+        for action in actions:
+            if action not in seen:
+                unique.append(action)
+                seen.add(action)
+        return unique
+
+    def evidence(self) -> Dict[str, object]:
+        return {
+            "issues": [issue.to_dict() for issue in self.issues],
+            "pull_requests": [pr.to_dict() for pr in self.pull_requests],
+            "branches": [br.to_dict() for br in self.branches],
+            "workflow_runs": [run.to_dict() for run in self.runs],
+        }
+
+
+RECOMMENDATIONS: Dict[str, List[str]] = {
+    STATE_BRANCH_ONLY: [
+        "Delete stale automation branch to prevent duplicate chains",
+        "Recreate or reopen the corresponding micro issue if work must resume",
+    ],
+    STATE_ISSUE_ONLY_ASSIGNED: [
+        "Unassign the issue or requeue the next micro task before re-dispatching",
+        "Ensure branch creation/PR bootstrapping automation kicks in",
+    ],
+    STATE_PR_CLOSED_CONFLICT: [
+        "Close conflicting PRs with explanatory comment",
+        "Delete associated automation branches",
+        "Recreate micro issue (suffix -R1) once cleanup completes",
+    ],
+    STATE_CI_STUCK: [
+        "Cancel stuck workflow runs and trigger fresh CI dispatch",
+        "Inspect workflow logs for blocking failures",
+    ],
+    STATE_DUPLICATE_PRS: [
+        "Keep oldest PR open and close later duplicates",
+        "Ensure assignment mutex prevents parallel automation chains",
+    ],
+}
+
+
+def run(cmd: List[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        check=check,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def gh_api(path: str, *, params: Optional[Dict[str, str]] = None) -> List[Dict[str, object]]:
+    params = params or {}
+    query = urlencode(params)
+    full_path = path if not query else f"{path}?{query}"
+    result = run(["gh", "api", full_path])
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ChainConsistencyError(f"Failed to parse gh api response for {full_path}: {exc}") from exc
+    if isinstance(data, dict) and "items" in data:
+        return data["items"]
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def gh_api_paginated(path: str, *, params: Optional[Dict[str, str]] = None) -> List[Dict[str, object]]:
+    params = params.copy() if params else {}
+    per_page = int(params.get("per_page", "100"))
+    params["per_page"] = str(per_page)
+    page = 1
+    aggregated: List[Dict[str, object]] = []
+    while True:
+        params["page"] = str(page)
+        batch = gh_api(path, params=params)
+        if not batch:
+            break
+        aggregated.extend(batch)
+        if len(batch) < per_page:
+            break
+        page += 1
+    return aggregated
+
+
+def parse_github_timestamp(value: Optional[str]) -> datetime:
+    if not value:
+        return datetime.now(timezone.utc)
+    try:
+        if value.endswith("Z"):
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+def normalize_chain_id(series: str, micro: str) -> str:
+    return f"RFC-{int(series):03d}-{int(micro):02d}"
+
+
+def extract_chain_id(text: Optional[str]) -> Optional[str]:
+    if not text:
+        return None
+    match = CHAIN_PATTERN.search(text)
+    if not match:
+        return None
+    return normalize_chain_id(match.group(1), match.group(2))
+
+
+def extract_chain_id_from_branch(branch: str) -> Optional[str]:
+    match = BRANCH_PATTERN.search(branch)
+    if not match:
+        return extract_chain_id(branch)
+    return normalize_chain_id(match.group(1), match.group(2))
+
+
+def collect_issues(repo: str) -> Dict[str, List[IssueInfo]]:
+    issues_data = gh_api_paginated(f"repos/{repo}/issues", params={"state": "all"})
+    chains: Dict[str, List[IssueInfo]] = {}
+    for issue in issues_data:
+        if "pull_request" in issue:
+            continue
+        chain_id = extract_chain_id(issue.get("title"))
+        if not chain_id:
+            continue
+        info = IssueInfo(
+            number=issue["number"],
+            title=issue.get("title", ""),
+            state=issue.get("state", ""),
+            assignees=[assignee.get("login") for assignee in issue.get("assignees", []) if assignee.get("login")],
+            url=issue.get("html_url", ""),
+            updated_at=issue.get("updated_at"),
+        )
+        chains.setdefault(chain_id, []).append(info)
+    return chains
+
+
+def collect_pull_requests(repo: str) -> Dict[str, List[PullInfo]]:
+    pulls_data = gh_api_paginated(f"repos/{repo}/pulls", params={"state": "all"})
+    chains: Dict[str, List[PullInfo]] = {}
+    for pr in pulls_data:
+        title = pr.get("title", "")
+        head_ref = pr.get("head", {}).get("ref", "")
+        chain_id = extract_chain_id(title) or extract_chain_id_from_branch(head_ref)
+        if not chain_id:
+            continue
+        info = PullInfo(
+            number=pr["number"],
+            title=title,
+            state=pr.get("state", ""),
+            merged=bool(pr.get("merged_at")),
+            draft=pr.get("draft", False),
+            head_ref=head_ref,
+            source_branch=head_ref,
+            url=pr.get("html_url", ""),
+            updated_at=pr.get("updated_at"),
+            closed_at=pr.get("closed_at"),
+        )
+        chains.setdefault(chain_id, []).append(info)
+    return chains
+
+
+def collect_branches(repo: str) -> Dict[str, List[BranchInfo]]:
+    branches_data = gh_api_paginated(f"repos/{repo}/branches")
+    chains: Dict[str, List[BranchInfo]] = {}
+    for branch in branches_data:
+        name = branch.get("name", "")
+        chain_id = extract_chain_id_from_branch(name)
+        if not chain_id:
+            continue
+        info = BranchInfo(
+            name=name,
+            protected=branch.get("protected", False),
+            url=branch.get("_links", {}).get("html", ""),
+        )
+        chains.setdefault(chain_id, []).append(info)
+    return chains
+
+
+def collect_workflow_runs(repo: str, *, max_runs: int) -> Dict[str, List[RunInfo]]:
+    runs_data = gh_api_paginated(f"repos/{repo}/actions/runs", params={"per_page": str(max_runs)})
+    chains: Dict[str, List[RunInfo]] = {}
+    for run in runs_data[:max_runs]:
+        branch = run.get("head_branch", "")
+        chain_id = extract_chain_id_from_branch(branch)
+        if not chain_id:
+            continue
+        info = RunInfo(
+            run_id=run.get("id"),
+            workflow_name=run.get("name", ""),
+            head_branch=branch,
+            status=run.get("status", ""),
+            conclusion=run.get("conclusion"),
+            created_at=run.get("created_at", ""),
+            url=run.get("html_url", ""),
+        )
+        chains.setdefault(chain_id, []).append(info)
+    return chains
+
+
+def build_chain_records(repo: str, *, max_runs: int) -> Dict[str, ChainRecord]:
+    chains: Dict[str, ChainRecord] = {}
+
+    def ensure(chain_id: str) -> ChainRecord:
+        return chains.setdefault(chain_id, ChainRecord(chain_id=chain_id))
+
+    issue_map = collect_issues(repo)
+    for chain_id, issues in issue_map.items():
+        ensure(chain_id).issues.extend(issues)
+
+    pr_map = collect_pull_requests(repo)
+    for chain_id, prs in pr_map.items():
+        ensure(chain_id).pull_requests.extend(prs)
+
+    branch_map = collect_branches(repo)
+    for chain_id, branches in branch_map.items():
+        ensure(chain_id).branches.extend(branches)
+
+    run_map = collect_workflow_runs(repo, max_runs=max_runs)
+    for chain_id, runs in run_map.items():
+        ensure(chain_id).runs.extend(runs)
+
+    return chains
+
+
+def generate_plan(repo: str, *, max_runs: int, now: Optional[datetime] = None) -> Dict[str, object]:
+    now = now or datetime.now(timezone.utc)
+    records = build_chain_records(repo, max_runs=max_runs)
+    chains_output: List[Dict[str, object]] = []
+    state_counts: Dict[str, int] = {state: 0 for state in KNOWN_STATES}
+
+    for chain_id, record in sorted(records.items()):
+        states = record.detect_states(now=now)
+        if not states:
+            continue
+        for state in states:
+            state_counts[state] += 1
+        chains_output.append(
+            {
+                "chain_id": chain_id,
+                "states": states,
+                "recommended_actions": record.recommended_actions(states),
+                "evidence": record.evidence(),
+            }
+        )
+
+    flagged = len(chains_output)
+    summary = {
+        "chains_total": len(records),
+        "chains_flagged": flagged,
+        "state_counts": {k: v for k, v in state_counts.items() if v},
+    }
+
+    return {
+        "generated_at": now.isoformat(),
+        "repo": repo,
+        "summary": summary,
+        "chains": chains_output,
+    }
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Detect automation chain inconsistencies")
+    parser.add_argument("--repo", help="owner/name repository (defaults to GITHUB_REPOSITORY)")
+    parser.add_argument("--output", default="chain_reset_plan.json", help="Path to write remediation plan JSON")
+    parser.add_argument("--max-runs", type=int, default=200, help="Maximum workflow runs to inspect")
+    parser.add_argument("--destructive", action="store_true", help="Execute destructive cleanup (not yet implemented)")
+    parser.add_argument("--print", action="store_true", help="Print plan JSON to stdout as well")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        raise ChainConsistencyError("Repository must be provided via --repo or GITHUB_REPOSITORY env var")
+
+    if args.destructive:
+        print(
+            "Destructive mode is not implemented yet; generating dry-run plan only.",
+            file=sys.stderr,
+        )
+
+    plan = generate_plan(repo, max_runs=args.max_runs)
+    output_path = os.path.abspath(args.output)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as fh:
+        json.dump(plan, fh, indent=2)
+
+    print(f"Chain consistency plan written to {output_path}")
+    flagged = plan["summary"]["chains_flagged"]
+    if flagged:
+        print(f"Detected {flagged} chain(s) requiring attention.")
+    else:
+        print("No inconsistent chains detected.")
+
+    if args.print:
+        print(json.dumps(plan, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python/production/rfc_assignment_mutex.py
+++ b/scripts/python/production/rfc_assignment_mutex.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""RFC series assignment mutex helper (Flow-RFC-009).
+
+Ensures only one open issue per RFC series is actively assigned to automation.
+- Creates/updates a tracking issue named "RFC-XYZ Series State" storing JSON state
+- Fails with status code 1 when another issue in the same series is already active
+- Adds queued issues to tracking document for visibility
+
+Usage:
+    python rfc_assignment_mutex.py --owner OWNER --repo NAME --issue-number 123
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+API_URL = "https://api.github.com/graphql"
+SERIES_PATTERN = re.compile(r"(?:Game-)?RFC-(\d{1,4})-(\d{1,3})", re.IGNORECASE)
+TRACKING_TITLE_TEMPLATE = "{series} Series State"
+
+
+class MutexError(RuntimeError):
+    pass
+
+
+def token() -> str:
+    tok = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not tok:
+        raise MutexError("GH_TOKEN or GITHUB_TOKEN must be set")
+    return tok
+
+
+def gql(query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    req = urllib.request.Request(
+        API_URL,
+        data=payload,
+        headers={
+            "Authorization": f"bearer {token()}",
+            "Content-Type": "application/json",
+            "User-Agent": "rfc-assignment-mutex/1.0",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    if data.get("errors"):
+        raise MutexError(json.dumps(data["errors"]))
+    return data.get("data", {})
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def extract_series(title: str) -> Optional[str]:
+    match = SERIES_PATTERN.search(title or "")
+    if not match:
+        return None
+    return f"RFC-{int(match.group(1)):03d}"
+
+
+def extract_series_micro(title: str) -> Optional[str]:
+    match = SERIES_PATTERN.search(title or "")
+    if not match:
+        return None
+    return f"RFC-{int(match.group(1)):03d}-{int(match.group(2)):02d}"
+
+
+@dataclass
+class SeriesState:
+    series: str
+    active_issue: Optional[int]
+    queue: List[int]
+    updated_at: str
+    version: int = 1
+
+    @classmethod
+    def default(cls, series: str) -> "SeriesState":
+        return cls(series=series, active_issue=None, queue=[], updated_at=now_iso())
+
+    @classmethod
+    def from_body(cls, series: str, body: str) -> "SeriesState":
+        json_block: Optional[str] = None
+        if body:
+            match = re.search(r"```json\s*(\{.*?\})\s*```", body, re.S)
+            if match:
+                json_block = match.group(1)
+        if not json_block:
+            return cls.default(series)
+        try:
+            data = json.loads(json_block)
+        except json.JSONDecodeError:
+            return cls.default(series)
+        return cls(
+            series=data.get("series", series),
+            active_issue=data.get("active_issue"),
+            queue=[int(x) for x in data.get("queue", [])],
+            updated_at=data.get("updated_at", now_iso()),
+            version=int(data.get("version", 1)),
+        )
+
+    def to_body(self) -> str:
+        state = {
+            "series": self.series,
+            "active_issue": self.active_issue,
+            "queue": self.queue,
+            "updated_at": self.updated_at,
+            "version": self.version,
+        }
+        body_template = "Tracking state for {series} automation.\n\n```json\n{state_json}\n```\n"
+        return body_template.format(series=self.series, state_json=json.dumps(state, indent=2))
+
+    def apply_candidate(self, candidate_issue: int, candidate_open: bool, active_issue_open: Optional[bool]) -> str:
+        if not candidate_open:
+            raise MutexError(f"Issue #{candidate_issue} is not open; cannot acquire lock")
+
+        if self.active_issue == candidate_issue:
+            if candidate_issue in self.queue:
+                self.queue.remove(candidate_issue)
+            self.updated_at = now_iso()
+            return "already-active"
+
+        if self.active_issue is None or (active_issue_open is False):
+            if self.active_issue and active_issue_open is False and self.active_issue in self.queue:
+                self.queue = [q for q in self.queue if q != self.active_issue]
+            self.active_issue = candidate_issue
+            if candidate_issue in self.queue:
+                self.queue.remove(candidate_issue)
+            self.updated_at = now_iso()
+            return "acquired"
+
+        if candidate_issue not in self.queue:
+            self.queue.append(candidate_issue)
+        self.updated_at = now_iso()
+        return "queued"
+
+
+ISSUE_QUERY = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    id
+    issue(number:$number){
+      id
+      number
+      title
+      state
+    }
+  }
+}
+"""
+
+SEARCH_TRACKING_QUERY = """
+query($query:String!){
+  search(query:$query, type:ISSUE, first:5){
+    nodes{
+      ... on Issue {
+        id
+        number
+        title
+        state
+        body
+        updatedAt
+      }
+    }
+  }
+}
+"""
+
+CREATE_TRACKING_MUTATION = """
+mutation($repoId:ID!,$title:String!,$body:String!){
+  createIssue(input:{repositoryId:$repoId,title:$title,body:$body}){
+    issue{ id number body }
+  }
+}
+"""
+
+UPDATE_ISSUE_MUTATION = """
+mutation($issueId:ID!,$body:String!){
+  updateIssue(input:{id:$issueId,body:$body}){
+    issue{ id number body }
+  }
+}
+"""
+
+
+def load_issue(owner: str, name: str, number: int) -> Dict[str, Any]:
+    data = gql(ISSUE_QUERY, {"owner": owner, "name": name, "number": number})
+    repo = data["repository"]
+    if not repo or not repo.get("issue"):
+        raise MutexError(f"Issue #{number} not found in {owner}/{name}")
+    return {
+        "repo_id": repo["id"],
+        "issue": repo["issue"],
+    }
+
+
+def search_tracking_issue(owner: str, name: str, series: str) -> Optional[Dict[str, Any]]:
+    query = f'repo:{owner}/{name} "{series} Series State" in:title'
+    data = gql(SEARCH_TRACKING_QUERY, {"query": query})
+    nodes = data.get("search", {}).get("nodes", [])
+    issues = [n for n in nodes if n.get("title") == TRACKING_TITLE_TEMPLATE.format(series=series)]
+    if not issues:
+        return None
+    issues.sort(key=lambda i: i.get("updatedAt"), reverse=True)
+    return issues[0]
+
+
+def create_tracking_issue(repo_id: str, series: str) -> Dict[str, Any]:
+    state = SeriesState.default(series)
+    body = state.to_body()
+    result = gql(
+        CREATE_TRACKING_MUTATION,
+        {"repoId": repo_id, "title": TRACKING_TITLE_TEMPLATE.format(series=series), "body": body},
+    )
+    return result["createIssue"]["issue"]
+
+
+def update_tracking_issue(issue_id: str, body: str) -> Dict[str, Any]:
+    result = gql(UPDATE_ISSUE_MUTATION, {"issueId": issue_id, "body": body})
+    return result["updateIssue"]["issue"]
+
+
+def ensure_series_state(owner: str, name: str, issue_number: int) -> Dict[str, Any]:
+    repo_issue = load_issue(owner, name, issue_number)
+    issue = repo_issue["issue"]
+    series_full = extract_series_micro(issue["title"])
+    if not series_full:
+        return {"status": "no-series", "issue_number": issue_number}
+    series = extract_series(issue["title"])
+    tracking_issue = search_tracking_issue(owner, name, series)
+    if not tracking_issue:
+        tracking_issue = create_tracking_issue(repo_issue["repo_id"], series)
+    original_body = tracking_issue.get("body") or ""
+    state = SeriesState.from_body(series, original_body)
+
+    active_issue_open: Optional[bool] = None
+    if state.active_issue and state.active_issue != issue_number:
+        active = load_issue(owner, name, state.active_issue)["issue"]
+        active_issue_open = active.get("state") == "OPEN"
+    status = state.apply_candidate(issue_number, issue.get("state") == "OPEN", active_issue_open)
+    new_body = state.to_body()
+    if new_body != original_body:
+        tracking_info = update_tracking_issue(tracking_issue["id"], new_body)
+        tracking_number = tracking_info["number"]
+    else:
+        tracking_number = tracking_issue.get("number")
+    result = {
+        "status": status,
+        "series": series,
+        "chain": series_full,
+        "active_issue": state.active_issue,
+        "queue": state.queue,
+        "tracking_issue_number": tracking_number,
+    }
+    return result
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ensure RFC series assignment mutex")
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--issue-number", type=int, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = ensure_series_state(args.owner, args.repo, args.issue_number)
+    except MutexError as exc:
+        print(json.dumps({"status": "error", "message": str(exc)}))
+        return 1
+    print(json.dumps(result))
+    if result.get("status") == "queued":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python/tests/automation/test_assignment_mutex.py
+++ b/scripts/python/tests/automation/test_assignment_mutex.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+import unittest
+from datetime import datetime, timezone
+
+PRODUCTION_DIR = pathlib.Path(__file__).parent.parent / "production"
+if str(PRODUCTION_DIR) not in sys.path:
+    sys.path.insert(0, str(PRODUCTION_DIR))
+
+import rfc_assignment_mutex as ram
+
+
+class SeriesExtractionTests(unittest.TestCase):
+    def test_extract_series(self):
+        self.assertEqual(ram.extract_series("Game-RFC-123-04: Task"), "RFC-123")
+        self.assertEqual(ram.extract_series("RFC-7-2 something"), "RFC-007")
+        self.assertIsNone(ram.extract_series("No series here"))
+
+    def test_extract_series_micro(self):
+        self.assertEqual(ram.extract_series_micro("Game-RFC-010-05: Task"), "RFC-010-05")
+        self.assertIsNone(ram.extract_series_micro("Random title"))
+
+
+class SeriesStateTests(unittest.TestCase):
+    def setUp(self):
+        self.state = ram.SeriesState.default("RFC-001")
+
+    def test_apply_candidate_acquires_when_empty(self):
+        status = self.state.apply_candidate(candidate_issue=10, candidate_open=True, active_issue_open=None)
+        self.assertEqual(status, "acquired")
+        self.assertEqual(self.state.active_issue, 10)
+        self.assertEqual(self.state.queue, [])
+
+    def test_apply_candidate_queue_when_active_open(self):
+        self.state.active_issue = 11
+        status = self.state.apply_candidate(candidate_issue=12, candidate_open=True, active_issue_open=True)
+        self.assertEqual(status, "queued")
+        self.assertIn(12, self.state.queue)
+        self.assertEqual(self.state.active_issue, 11)
+
+    def test_promote_when_active_closed(self):
+        self.state.active_issue = 20
+        self.state.queue = [21]
+        status = self.state.apply_candidate(candidate_issue=30, candidate_open=True, active_issue_open=False)
+        self.assertEqual(status, "acquired")
+        self.assertEqual(self.state.active_issue, 30)
+        self.assertNotIn(30, self.state.queue)
+
+    def test_already_active(self):
+        self.state.active_issue = 5
+        self.state.queue = [5, 6]
+        status = self.state.apply_candidate(candidate_issue=5, candidate_open=True, active_issue_open=True)
+        self.assertEqual(status, "already-active")
+        self.assertNotIn(5, self.state.queue)
+
+    def test_candidate_closed_raises(self):
+        with self.assertRaises(ram.MutexError):
+            self.state.apply_candidate(candidate_issue=99, candidate_open=False, active_issue_open=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/python/tests/automation/test_chain_consistency.py
+++ b/scripts/python/tests/automation/test_chain_consistency.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Ensure production directory on path
+import pathlib
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+
+PRODUCTION_DIR = pathlib.Path(__file__).parent.parent / "production"
+if str(PRODUCTION_DIR) not in sys.path:
+    sys.path.insert(0, str(PRODUCTION_DIR))
+
+import chain_consistency_manager as ccm
+
+
+class ChainIdentifierTests(unittest.TestCase):
+    def test_extract_chain_id_from_title(self):
+        self.assertEqual(ccm.extract_chain_id("Game-RFC-001-02: Sample Task"), "RFC-001-02")
+        self.assertEqual(ccm.extract_chain_id("RFC-010-07: Another Task"), "RFC-010-07")
+        self.assertIsNone(ccm.extract_chain_id("No chain here"))
+
+    def test_extract_chain_id_from_branch(self):
+        self.assertEqual(ccm.extract_chain_id_from_branch("copilot/rfc-123-04-awesome"), "RFC-123-04")
+        self.assertEqual(ccm.extract_chain_id_from_branch("automation/rfc-5-1-reset"), "RFC-005-01")
+        self.assertEqual(ccm.extract_chain_id_from_branch("feature/something"), None)
+
+
+class ChainStateDetectionTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime.now(timezone.utc)
+
+    def test_branch_only_state(self):
+        record = ccm.ChainRecord(
+            chain_id="RFC-001-02",
+            issues=[ccm.IssueInfo(number=1, title="Game-RFC-001-02: Done", state="closed", assignees=[], url="")],
+            branches=[ccm.BranchInfo(name="copilot/rfc-001-02-task", protected=False, url="")],
+            pull_requests=[],
+            runs=[],
+        )
+        states = record.detect_states(now=self.now)
+        self.assertIn(ccm.STATE_BRANCH_ONLY, states)
+
+    def test_issue_only_assigned_state(self):
+        record = ccm.ChainRecord(
+            chain_id="RFC-002-03",
+            issues=[ccm.IssueInfo(number=2, title="Game-RFC-002-03", state="open", assignees=["bot"], url="")],
+        )
+        states = record.detect_states(now=self.now)
+        self.assertIn(ccm.STATE_ISSUE_ONLY_ASSIGNED, states)
+
+    def test_duplicate_prs_state(self):
+        record = ccm.ChainRecord(
+            chain_id="RFC-010-05",
+            pull_requests=[
+                ccm.PullInfo(
+                    number=11,
+                    title="Game-RFC-010-05",
+                    state="open",
+                    merged=False,
+                    draft=False,
+                    head_ref="copilot/rfc-010-05-a",
+                    source_branch="copilot/rfc-010-05-a",
+                    url="",
+                ),
+                ccm.PullInfo(
+                    number=12,
+                    title="Game-RFC-010-05",
+                    state="open",
+                    merged=False,
+                    draft=False,
+                    head_ref="copilot/rfc-010-05-b",
+                    source_branch="copilot/rfc-010-05-b",
+                    url="",
+                ),
+            ],
+        )
+        states = record.detect_states(now=self.now)
+        self.assertIn(ccm.STATE_DUPLICATE_PRS, states)
+
+    def test_ci_stuck_state(self):
+        created_at = (self.now - timedelta(minutes=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        record = ccm.ChainRecord(
+            chain_id="RFC-020-01",
+            runs=[
+                ccm.RunInfo(
+                    run_id=100,
+                    workflow_name="ci",
+                    head_branch="copilot/rfc-020-01-branch",
+                    status="in_progress",
+                    conclusion=None,
+                    created_at=created_at,
+                    url="https://example.com/run/100",
+                )
+            ],
+        )
+        states = record.detect_states(now=self.now)
+        self.assertIn(ccm.STATE_CI_STUCK, states)
+
+    def test_recommended_actions_dedup(self):
+        record = ccm.ChainRecord(chain_id="RFC-030-01")
+        actions = record.recommended_actions([ccm.STATE_BRANCH_ONLY, ccm.STATE_BRANCH_ONLY])
+        self.assertEqual(len(actions), len(set(actions)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add chain health scan workflow and detector per docs/flow-rfcs/Flow-RFC-008-chain-consistency-and-atomic-reset.md
- enforce RFC series assignment mutex with tracking issues per docs/flow-rfcs/Flow-RFC-009-assignment-mutex-and-race-prevention.md

## Testing
- python -m pytest scripts/python/tests/automation/test_assignment_mutex.py scripts/python/tests/automation/test_chain_consistency.py -v

## RFC Links
- [Flow-RFC-008](https://github.com/ApprenticeGC/ithome-ironman-2025/blob/main/docs/flow-rfcs/Flow-RFC-008-chain-consistency-and-atomic-reset.md)
- [Flow-RFC-009](https://github.com/ApprenticeGC/ithome-ironman-2025/blob/main/docs/flow-rfcs/Flow-RFC-009-assignment-mutex-and-race-prevention.md)