### PR TITLE
feat(flow): route event bus signals downstream

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -55,3 +55,39 @@ jobs:
             --repo "$REPO_NAME" \
             --issue-number ${{ github.event.inputs.issue_number }} \
             --assign-mode bot
+
+      - name: Emit issue assignment event
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          export PYTHONPATH=scripts/python/production:$PYTHONPATH
+          python <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+
+          from event_bus import EventBusError, emit_event
+
+          owner = os.environ['OWNER']
+          repo = os.environ['REPO_NAME']
+          issue_number = int(os.environ['ISSUE_NUMBER'])
+          result = subprocess.run(['gh', 'issue', 'view', str(issue_number), '--json', 'title'], capture_output=True, text=True, check=True)
+          issue_title = json.loads(result.stdout)['title']
+          match = re.search(r'(?:Game-)?RFC-(\d+)-(\d+)', issue_title)
+          if match:
+              series = f"RFC-{int(match.group(1)):03d}"
+              micro = f"{int(match.group(2)):02d}"
+              payload = {'issue': issue_number, 'series': series, 'micro': micro}
+              try:
+                  emit_event('rfc.issue.assigned', payload, repo=f"{owner}/{repo}", source='workflow:assign-copilot')
+              except EventBusError as exc:
+                  print(f'Warning: failed to emit rfc.issue.assigned event: {exc}', file=os.sys.stderr)
+          else:
+              print('Issue title did not contain RFC identifier; skipping event emission', file=os.sys.stderr)
+          PY

--- a/.github/workflows/chain-health-scan.yml
+++ b/.github/workflows/chain-health-scan.yml
@@ -39,7 +39,9 @@ jobs:
           cmd=(python scripts/python/production/chain_consistency_manager.py
                --repo "${{ github.repository }}"
                --output chain_reset_plan.json
-               --max-runs "${CHAIN_MAX_RUNS}")
+               --max-runs "${CHAIN_MAX_RUNS}"
+               --emit-events
+               --event-source workflow:chain-health-scan)
           if [ "${CHAIN_DESTRUCTIVE}" = "true" ]; then
             cmd+=("--destructive")
           fi

--- a/.github/workflows/event-router.yml
+++ b/.github/workflows/event-router.yml
@@ -1,0 +1,143 @@
+name: event-router
+
+on:
+  repository_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract event payload
+        id: prepare
+        run: |
+          python <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event_path = Path(os.environ['GITHUB_EVENT_PATH'])
+          event = json.loads(event_path.read_text())
+          client_payload = event.get('client_payload') or {}
+          Path('artifacts').mkdir(exist_ok=True)
+          Path('artifacts/client_payload.json').write_text(json.dumps(client_payload, indent=2))
+          Path('artifacts/payload_only.json').write_text(json.dumps(client_payload.get('payload') or {}, indent=2))
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as gh:
+              gh.write(f"event_type={event.get('action','')}\n")
+          PY
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate event envelope schema
+        run: |
+          npm install -g ajv-cli@5
+          ajv validate -s docs/events/schema/repository-dispatch.schema.json -d artifacts/client_payload.json
+
+      - name: Validate issue-assigned payload schema
+        if: steps.prepare.outputs.event_type == 'rfc.issue.assigned'
+        run: ajv validate -s docs/events/schema/rfc.issue.assigned.json -d artifacts/payload_only.json
+
+      - name: Validate chain-broken payload schema
+        if: steps.prepare.outputs.event_type == 'rfc.chain.broken'
+        run: ajv validate -s docs/events/schema/rfc.chain.broken.json -d artifacts/payload_only.json
+
+      - name: Append event log
+        run: |
+          python <<'PY'
+          import json
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          event_log = Path('event_log.jsonl')
+          client_payload = json.loads(Path('artifacts/client_payload.json').read_text())
+          record = {
+              'timestamp': datetime.now(timezone.utc).isoformat(),
+              'event_type': '${{ steps.prepare.outputs.event_type }}',
+              'payload': client_payload,
+          }
+          with event_log.open('a', encoding='utf-8') as fh:
+              fh.write(json.dumps(record) + '\n')
+          PY
+
+      - name: Route downstream workflows
+        env:
+          EVENT_TYPE: ${{ steps.prepare.outputs.event_type }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          from typing import Dict, List, Any
+
+
+          def load_payload(path: str) -> Dict[str, Any]:
+              try:
+                  with open(path, "r", encoding="utf-8") as handle:
+                      return json.load(handle)
+              except FileNotFoundError:
+                  return {}
+              except json.JSONDecodeError as exc:  # Defensive; schema should prevent this.
+                  print(f"Invalid payload JSON: {exc}", file=sys.stderr)
+                  return {}
+
+
+          event_type = os.environ.get("EVENT_TYPE", "")
+          payload = load_payload("artifacts/payload_only.json")
+          routes: List[Dict[str, Any]] = []
+
+          if event_type == "rfc.issue.assigned":
+              routes.append({"workflow": "pr-flow-monitor.yml"})
+          elif event_type == "rfc.chain.broken":
+              states = set(payload.get("states") or [])
+              if states.intersection({"PR_CLOSED_CONFLICT", "DUPLICATE_PRS"}):
+                  routes.append({"workflow": "rfc-cleanup-duplicates.yml"})
+              if states.intersection({"BRANCH_ONLY", "CI_STUCK"}):
+                  routes.append({"workflow": "cleanup-stalled-prs.yml"})
+
+
+          def dispatch(route: Dict[str, Any]) -> None:
+              workflow = route["workflow"]
+              ref = route.get("ref", "main")
+              inputs = route.get("inputs", {}) or {}
+              print(f"Dispatching workflow '{workflow}' on ref '{ref}' with inputs {inputs}.")
+              cmd = [
+                  "gh",
+                  "workflow",
+                  "run",
+                  str(workflow),
+                  "--ref",
+                  str(ref),
+              ]
+              if isinstance(inputs, dict):
+                  for key, value in inputs.items():
+                      cmd.extend(["-f", f"{key}={value}"])
+              subprocess.run(cmd, check=True)
+
+
+          if not routes:
+              print(f"No downstream routing defined for event type '{event_type}'.")
+          else:
+              for route in routes:
+                  dispatch(route)
+          PY
+
+      - name: Upload event artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: event-router-${{ github.run_id }}
+          path: |
+            artifacts/client_payload.json
+            artifacts/payload_only.json
+            event_log.jsonl

--- a/docs/events/schema/repository-dispatch.schema.json
+++ b/docs/events/schema/repository-dispatch.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RFC Automation Repository Dispatch Payload",
+  "type": "object",
+  "required": ["event_id", "source", "timestamp", "payload"],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9-]{8,}$"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/events/schema/rfc.chain.broken.json
+++ b/docs/events/schema/rfc.chain.broken.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Payload for rfc.chain.broken",
+  "type": "object",
+  "required": ["chain_id", "reason"],
+  "properties": {
+    "chain_id": { "type": "string", "pattern": "^RFC-\d{3}-\d{2}$" },
+    "reason": { "type": "string", "minLength": 1 },
+    "states": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/events/schema/rfc.issue.assigned.json
+++ b/docs/events/schema/rfc.issue.assigned.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Payload for rfc.issue.assigned",
+  "type": "object",
+  "required": ["issue", "series", "micro"],
+  "properties": {
+    "issue": { "type": "integer", "minimum": 1 },
+    "series": { "type": "string", "pattern": "^RFC-\d{3}$" },
+    "micro": { "type": "string", "pattern": "^\d{2}$" }
+  },
+  "additionalProperties": false
+}

--- a/docs/flow-rfcs/Flow-RFC-010-central-coordination-and-event-signaling.md
+++ b/docs/flow-rfcs/Flow-RFC-010-central-coordination-and-event-signaling.md
@@ -1,0 +1,79 @@
+# Flow-RFC-010: Central Coordination and Event Signaling Layer
+
+## Status
+In Progress (event router + emitter added 2025-09-20)
+
+## Problem
+Workflows currently operate via polling (cron + broad triggers). Consequences: latency, duplicate processing, wasted minutes, and races. No shared event bus or state aggregator.
+
+## Goals
+- Reduce reliance on cron schedules
+- Provide low-latency signaling between lifecycle stages (issue assigned → ingestion; PR ready → merge monitor)
+- Standardize event payload schema
+
+## Non-Goals
+- External infrastructure (Kafka, SQS) – must remain GitHub-native
+
+## Design
+Use `repository_dispatch` + structured JSON payloads as an internal event bus.
+
+### Event Types
+| Event | Producer | Consumer(s) | Payload Core |
+|-------|----------|-------------|--------------|
+| `rfc.issue.assigned` | assignment workflow | PR creator monitor | `{ "issue": 123, "series": "RFC-093", "micro": "02" }` |
+| `rfc.pr.created` | PR creation detector | CI dispatcher, merge orchestrator | `{ "pr": 456, "issue": 123, "branch": "copilot/rfc-093-02" }` |
+| `rfc.pr.ready` | readiness evaluator | merge orchestrator | `{ "pr":456, "checks_status":"green" }` |
+| `rfc.pr.blocked` | diagnostics | human / auto-remediator | `{ "pr":456, "blockers":[...] }` |
+| `rfc.chain.broken` | chain consistency (RFC-008) | chain reset | `{ "chain_id":"RFC-093-02", "reason":"PR_CLOSED_CONFLICT" }` |
+
+### Implementation Components
+1. Event Emitter Helper (Python): `emit_event(event_type, payload)` → calls GitHub REST `POST /repos/:owner/:repo/dispatches`.
+2. Workflow `event-router.yml` listening on `repository_dispatch` and conditionally invoking other workflows (via `workflow_call`).
+3. Schema Validation: JSON Schema definitions in `docs/events/schema/` validated in CI (ajv CLI container step).
+4. Deduplication: Include `event_id` (UUIDv4) + `source` + timestamp; maintain short-lived in-memory (or issue comment) cache to drop duplicates.
+
+### Migration Strategy
+- Keep cron jobs initially but add event emission.
+- Once reliability proven, increase cron interval or remove redundant ones.
+
+## Security / Abuse Considerations
+- Only workflows / internal scripts emit events (using GITHUB_TOKEN scope limited to repo).
+- Validate `client_payload.event_id` length & pattern.
+
+## Observability
+- Event log artifact `event_log.jsonl` appended by router.
+- Metrics: counts per event_type, median routing latency.
+
+## Test Plan
+- Unit: schema validation for each event type
+- Integration: end-to-end dispatch from assignment to merge orchestrator
+- Failure injection: malformed payload rejected gracefully with logged error
+
+## Risks & Mitigations
+| Risk | Mitigation |
+|------|------------|
+| Event loss (rate limits) | Retry with jitter, fallback cron path remains |
+| Duplicate events | event_id caching (60m TTL) |
+| Payload drift | JSON schema enforced in CI |
+
+## Acceptance Criteria
+- 50% reduction in average time from PR readiness to merge attempt
+- No duplicate processing events in test harness
+- All events validated against schema; zero schema drift errors over 7 days
+
+## Rollout
+Phase 1: implement emitter + router (log only)
+Phase 2: route to CI + merge monitor
+Phase 3: deprecate selected cron workflows.
+
+## Implementation (Phase 1)
+- Added `scripts/python/production/event_bus.py` with `emit_event` helper (and CLI) for repository_dispatch triggers.
+- New workflow `.github/workflows/event-router.yml` validates payloads against `docs/events/schema/` and records them to `event_log.jsonl`.
+- Assignment workflow emits `rfc.issue.assigned` events; chain health scan emits `rfc.chain.broken` when inconsistencies are detected.
+
+## Implementation (Phase 2)
+- Event router now dispatches downstream automation:
+  - `rfc.issue.assigned` immediately triggers `pr-flow-monitor.yml` to kick the PR creation + CI readiness checks without waiting for the 5-minute cron.
+  - `rfc.chain.broken` invokes targeted cleanup workflows, running `rfc-cleanup-duplicates.yml` for duplicate/conflict states and `cleanup-stalled-prs.yml` for branch-only / CI-stuck states.
+- Router permissions elevated to `actions: write` so it can call `gh workflow run` safely with the repo token.
+- Phase 2 keeps logging artifacts for observability while reducing end-to-end latency by running the same remediation flows proactively.

--- a/scripts/python/production/event_bus.py
+++ b/scripts/python/production/event_bus.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Repository dispatch event emitter helpers (Flow-RFC-010)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+API_URL_TEMPLATE = "https://api.github.com/repos/{repo}/dispatches"
+
+
+class EventBusError(RuntimeError):
+    pass
+
+
+def _default_repo() -> str:
+    repo = os.environ.get("REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        raise EventBusError("Repository must be provided via --repo or REPO/GITHUB_REPOSITORY env vars")
+    return repo
+
+
+def _token() -> str:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise EventBusError("GH_TOKEN or GITHUB_TOKEN must be set to emit events")
+    return token
+
+
+def emit_event(
+    event_type: str,
+    payload: Dict[str, Any],
+    *,
+    repo: Optional[str] = None,
+    token: Optional[str] = None,
+    event_id: Optional[str] = None,
+    source: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Emit a repository_dispatch event.
+
+    Returns the payload that was sent (including metadata) for logging/testing.
+    """
+    repo = repo or _default_repo()
+    token = token or _token()
+    event_id = event_id or str(uuid.uuid4())
+    source = source or os.environ.get("EVENT_SOURCE") or "automation"
+
+    envelope = {
+        "event_id": event_id,
+        "source": source,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "payload": payload,
+    }
+
+    data = json.dumps({"event_type": event_type, "client_payload": envelope}).encode("utf-8")
+    req = urllib.request.Request(
+        API_URL_TEMPLATE.format(repo=repo),
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "rfc-event-bus/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            # 204 expected, but we don't rely on status code here
+            resp.read()
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        body = exc.read().decode("utf-8", errors="replace") if hasattr(exc, "read") else ""
+        raise EventBusError(f"GitHub API error {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:  # type: ignore[attr-defined]
+        raise EventBusError(f"Network error emitting event: {exc}") from exc
+
+    return envelope
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit repository_dispatch events")
+    parser.add_argument("event_type", help="Event type (used as repository_dispatch action)")
+    parser.add_argument("payload", help="JSON payload to include under client_payload.payload")
+    parser.add_argument("--repo", help="Target repository (owner/name)")
+    parser.add_argument("--source", help="Event source identifier")
+    parser.add_argument("--event-id", help="Explicit event id (defaults to UUID)")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    try:
+        payload_obj = json.loads(args.payload)
+    except json.JSONDecodeError as exc:
+        raise EventBusError(f"Invalid JSON payload: {exc}") from exc
+
+    envelope = emit_event(
+        event_type=args.event_type,
+        payload=payload_obj,
+        repo=args.repo,
+        event_id=args.event_id,
+        source=args.source,
+    )
+    print(json.dumps({"status": "ok", "envelope": envelope}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except EventBusError as exc:
+        print(json.dumps({"status": "error", "message": str(exc)}), file=sys.stderr)
+        sys.exit(1)

--- a/scripts/python/tests/automation/test_event_bus.py
+++ b/scripts/python/tests/automation/test_event_bus.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+from unittest import mock
+
+import pytest
+
+PRODUCTION_DIR = pathlib.Path(__file__).parent.parent / "production"
+if str(PRODUCTION_DIR) not in sys.path:
+    sys.path.insert(0, str(PRODUCTION_DIR))
+
+import event_bus
+
+
+class DummyResponse:
+    def __init__(self, status: int = 204, payload: bytes | None = None):
+        self.status = status
+        self._payload = payload or b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *excinfo):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+@mock.patch("urllib.request.urlopen")
+@mock.patch("event_bus.uuid.uuid4", return_value="uuid-1234")
+@mock.patch("event_bus.datetime")
+def test_emit_event_envelope(datetime_mock, uuid_mock, urlopen_mock, monkeypatch):
+    datetime_mock.now.return_value.isoformat.return_value = "2025-09-20T01:02:03+00:00"
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+    urlopen_mock.return_value = DummyResponse()
+
+    payload = {"issue": 123}
+    envelope = event_bus.emit_event("rfc.issue.assigned", payload)
+
+    request: urllib.request.Request = urlopen_mock.call_args.args[0]  # type: ignore[attr-defined]
+    assert request.full_url.endswith("/repos/org/repo/dispatches")
+    assert request.get_header("Authorization") == "Bearer test-token"
+
+    sent = json.loads(request.data.decode("utf-8"))
+    assert sent["event_type"] == "rfc.issue.assigned"
+    assert sent["client_payload"]["event_id"] == "uuid-1234"
+    assert sent["client_payload"]["payload"] == payload
+    assert envelope == sent["client_payload"]
+
+
+@mock.patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError("url", 422, "Unprocessable", {}, None))
+def test_emit_event_http_error(urlopen_mock, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+    with pytest.raises(event_bus.EventBusError):
+        event_bus.emit_event("type", {})
+
+
+@mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom"))
+def test_emit_event_network_error(urlopen_mock, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "org/repo")
+    with pytest.raises(event_bus.EventBusError):
+        event_bus.emit_event("type", {})


### PR DESCRIPTION
## Summary
- wire the event router into downstream automation workflows
- send fc.issue.assigned signals directly to pr-flow-monitor.yml for immediate CI orchestration
- dispatch cleanup workflows for fc.chain.broken states and document the Phase 2 routing

## Testing
- python -m pytest scripts/python/tests/automation/test_event_bus.py scripts/python/tests/automation/test_chain_consistency.py scripts/python/tests/automation/test_assignment_mutex.py -v

## RFC
- [Flow-RFC-010](docs/flow-rfcs/Flow-RFC-010-central-coordination-and-event-signaling.md)
- [PR Checklist](docs/playbook/PLAYBOOK.md#pr-checklist)

## Acceptance Criteria
- [x] fc.issue.assigned events trigger the PR flow monitor without waiting for cron
- [x] fc.chain.broken events dispatch the appropriate cleanup workflows
- [x] Event router continues to validate envelopes and log payloads
