### PR TITLE
feat(flow): add shadow monitor workflow for RFC-013 phase2

### DIFF
--- a/.github/workflows/flow-monitor-shadow.yml
+++ b/.github/workflows/flow-monitor-shadow.yml
@@ -1,0 +1,37 @@
+name: flow-monitor-shadow
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  shadow:
+    runs-on: ubuntu-latest
+    environment: copilot
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Shadow PR flow monitor
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}  # pragma: allowlist secret
+          AUTO_APPROVE_PAT: ${{ secrets.AUTO_APPROVE_TOKEN }}  # pragma: allowlist secret
+          REPO: ${{ github.repository }}
+        run: |
+          export PYTHONPATH="scripts/python/production:$PYTHONPATH"
+          python3 scripts/python/production/orchestrator_cli.py monitor --target pr-flow --repo "$REPO" --shadow
+
+      - name: Shadow auto-merge monitor
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN || secrets.GITHUB_TOKEN }}  # pragma: allowlist secret
+          AUTO_APPROVE_PAT: ${{ secrets.AUTO_APPROVE_TOKEN }}  # pragma: allowlist secret
+          REPO: ${{ github.repository }}
+        run: |
+          export PYTHONPATH="scripts/python/production:$PYTHONPATH"
+          python3 scripts/python/production/orchestrator_cli.py monitor --target auto-merge --repo "$REPO" --shadow

--- a/docs/flow-rfcs/Flow-RFC-013-workflow-consolidation-and-simplification.md
+++ b/docs/flow-rfcs/Flow-RFC-013-workflow-consolidation-and-simplification.md
@@ -68,4 +68,9 @@ Phase 3: cutover + archive legacy.
 - Introduced `scripts/python/production/orchestrator_cli.py` with `monitor`, `approve`, `diagnose`, and `cleanup` subcommands; legacy workflows now route through the CLI for consistent execution paths.
 - Updated monitors (`pr-flow-monitor.yml`, `auto-approve-workflows.yml`, `chain-health-scan.yml`) to call the orchestrator CLI, setting the stage for future consolidation into a single `flow-monitor.yml`.
 
-**Next**: shadow legacy monitors behind the orchestrator and collapse redundant schedules before deprecating the original workflows.
+## Implementation (Phase 2)
+- Added `--shadow` support to the orchestrator CLI monitor command so workflows can execute in log-only mode without mutating repo state.
+- Introduced `.github/workflows/flow-monitor-shadow.yml`, scheduled alongside the existing monitors to exercise the unified orchestrator in shadow mode for PR-flow and auto-merge scenarios.
+- Shadow runs rely on the same secrets/environment wiring as production monitors, providing signal coverage ahead of the full cutover while keeping legacy automation active.
+
+**Next**: compare shadow logs against legacy automation for a full week, then retire the standalone monitor workflows in favour of a consolidated `flow-monitor.yml`.

--- a/scripts/python/tests/automation/test_orchestrator_cli.py
+++ b/scripts/python/tests/automation/test_orchestrator_cli.py
@@ -30,12 +30,21 @@ def test_monitor_auto_merge_sets_pr_and_event(monkeypatch):
     monkeypatch.delenv("GITHUB_EVENT", raising=False)
 
     with mock.patch("ensure_automerge_or_comment.main") as auto_merge_mock:
-        orchestrator_cli.run_monitor("auto-merge", "target/repo", 42, "{" "key" ": " "value" "}")
+        orchestrator_cli.run_monitor("auto-merge", "target/repo", 42, '{"key": "value"}')
         auto_merge_mock.assert_called_once()
 
     assert os.environ["REPO"] == "existing/repo"
     assert "PR_NUMBER" not in os.environ
     assert "GITHUB_EVENT" not in os.environ
+
+
+def test_monitor_shadow_skips_execution(monkeypatch):
+    monkeypatch.delenv("REPO", raising=False)
+
+    with mock.patch("monitor_pr_flow.main") as monitor_mock:
+        result = orchestrator_cli.run_monitor("pr-flow", "org/repo", None, None, shadow=True)
+        monitor_mock.assert_not_called()
+        assert result == 0
 
 
 def test_cleanup_argument_build(monkeypatch):


### PR DESCRIPTION
## Summary
- add shadow support to orchestrator_cli.py so monitors can run in log-only mode
- introduce low-monitor-shadow.yml to exercise the unified monitor on the same cadence as legacy workflows
- document RFC-013 Phase 2 completion and extend CLI tests to cover the new shadow behaviour

## Testing
- python -m pytest scripts/python/tests/automation/test_orchestrator_cli.py scripts/python/tests/automation/test_event_bus.py scripts/python/tests/automation/test_chain_consistency.py scripts/python/tests/automation/test_assignment_mutex.py -v
- dotnet build ./dotnet -warnaserror *(fails: Pure.DI generator DIE999 in GameConsole.Core.Registry)*

## RFC
- [Flow-RFC-013](docs/flow-rfcs/Flow-RFC-013-workflow-consolidation-and-simplification.md)
- [PR Checklist](docs/playbook/PLAYBOOK.md#pr-checklist)

## Acceptance Criteria
- [x] Unified monitor runs in passive shadow mode without mutating state
- [x] Shadow workflow mirrors existing schedules for observability
- [x] Documentation reflects Phase 2 rollout plan
