### PR TITLE
feat(flow): allow notion page input in micro generator workflow

### DIFF
--- a/.github/workflows/generate-micro.yml
+++ b/.github/workflows/generate-micro.yml
@@ -5,7 +5,10 @@ on:
     inputs:
       rfc_path:
         description: 'Path to RFC file (e.g., docs/RFC/RFC-090-agent-flow-smoke-test.md)'
-        required: true
+        required: false
+      notion_page_id:
+        description: 'Notion page ID to ingest (takes precedence over rfc_path)'
+        required: false
       assign_mode:
         description: 'Assignee preference (bot|user|auto)'
         required: false
@@ -26,13 +29,33 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Generate micro issues from RFC
+      - name: Generate micro issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}  # pragma: allowlist secret
           REPO: ${{ github.repository }}
+        shell: bash
         run: |
-          python scripts/python/production/generate_micro_issues_from_rfc.py \
-            --rfc-path "${{ github.event.inputs.rfc_path }}" \
-            --owner "${{ github.repository_owner }}" \
-            --repo "${{ github.event.repository.name }}" \
-            --assign-mode "${{ github.event.inputs.assign_mode }}"
+          set -euo pipefail
+          OWNER="${{ github.repository_owner }}"
+          REPO_NAME="${{ github.event.repository.name }}"
+          RFC_PATH="${{ github.event.inputs.rfc_path || '' }}"
+          NOTION_PAGE_ID="${{ github.event.inputs.notion_page_id || '' }}"
+          ASSIGN_MODE="${{ github.event.inputs.assign_mode }}"
+
+          if [ -n "$NOTION_PAGE_ID" ]; then
+            python scripts/python/production/generate_micro_issues_from_rfc.py \
+              --notion-page-id "$NOTION_PAGE_ID" \
+              --owner "$OWNER" \
+              --repo "$REPO_NAME" \
+              --assign-mode "$ASSIGN_MODE"
+          elif [ -n "$RFC_PATH" ]; then
+            python scripts/python/production/generate_micro_issues_from_rfc.py \
+              --rfc-path "$RFC_PATH" \
+              --owner "$OWNER" \
+              --repo "$REPO_NAME" \
+              --assign-mode "$ASSIGN_MODE"
+          else
+            echo "::error::Provide either rfc_path, notion_page_id, or notion_collection input." >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- extend generate-micro.yml to accept 
otion_page_id and invoke the Notion ingestion path directly
- surface NOTION_TOKEN to the workflow with a guard and fall back to the existing RFC markdown path if Notion inputs are absent
- manually dispatched the workflow (
otion_page_id=deadbeef, branch copilot/notion-micro-workflow) to confirm the new branch executes the Notion code path (fails with Notion validation error as expected for placeholder input)

## Testing
- gh workflow run generate-micro.yml --ref copilot/notion-micro-workflow --field notion_page_id=deadbeef --field assign_mode=bot --field rfc_path=
