### PR TITLE
chore(flow): freeze copilot assignment for dependency plan

### DIFF
--- a/.github/workflows/assign-copilot-to-issue.yml
+++ b/.github/workflows/assign-copilot-to-issue.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   assign:
+    if: ${{ vars.COPILOT_ASSIGN_DISABLED != '1' }}
     environment: copilot
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/export-rfc-dependencies.yml
+++ b/.github/workflows/export-rfc-dependencies.yml
@@ -1,0 +1,34 @@
+name: export-rfc-dependencies
+
+on:
+  workflow_dispatch:
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    environment: copilot
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Export Notion RFC metadata
+        env:
+          NOTION_TOKEN: ${{ secrets.COPILOT_MCP_NOTION_API_KEY }}
+        run: |
+          set -euo pipefail
+          python scripts/python/production/export_rfc_page_metadata.py \
+            --architecture-collection 2722b68ae80081608911f6375c111676 \
+            --implementation-collection 2722b68ae8008115b215cfa0c4aa3908 \
+            --output notion_rfc_pages.json
+          cat notion_rfc_pages.json
+
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: notion-rfc-pages
+          path: notion_rfc_pages.json

--- a/docs/status/rfc-dependencies.json
+++ b/docs/status/rfc-dependencies.json
@@ -1,0 +1,135 @@
+{
+  "architecture": {
+    "ARCH-RFC-002": {
+      "title": "Architecture RFC 002"
+    },
+    "ARCH-RFC-003": {
+      "title": "Architecture RFC 003"
+    },
+    "ARCH-RFC-004": {
+      "title": "Architecture RFC 004"
+    },
+    "ARCH-RFC-005": {
+      "title": "Architecture RFC 005"
+    },
+    "ARCH-RFC-006": {
+      "title": "Architecture RFC 006"
+    },
+    "ARCH-RFC-007": {
+      "title": "Architecture RFC 007"
+    },
+    "ARCH-RFC-008": {
+      "title": "Architecture RFC 008"
+    },
+    "ARCH-RFC-009": {
+      "title": "Architecture RFC 009"
+    },
+    "ARCH-RFC-010": {
+      "title": "Architecture RFC 010"
+    },
+    "ARCH-RFC-011": {
+      "title": "Architecture RFC 011"
+    },
+    "ARCH-RFC-012": {
+      "title": "Architecture RFC 012"
+    },
+    "ARCH-RFC-013": {
+      "title": "Architecture RFC 013"
+    },
+    "ARCH-RFC-014": {
+      "title": "Architecture RFC 014"
+    }
+  },
+  "dependencies": {
+    "GAME-RFC-002-03": [
+      "ARCH-RFC-002"
+    ],
+    "GAME-RFC-003-01": [
+      "ARCH-RFC-003"
+    ],
+    "GAME-RFC-003-02": [
+      "ARCH-RFC-003"
+    ],
+    "GAME-RFC-003-03": [
+      "ARCH-RFC-003"
+    ],
+    "GAME-RFC-004-01": [
+      "ARCH-RFC-004"
+    ],
+    "GAME-RFC-004-02": [
+      "ARCH-RFC-004"
+    ],
+    "GAME-RFC-004-03": [
+      "ARCH-RFC-004"
+    ],
+    "GAME-RFC-005-01": [
+      "ARCH-RFC-005"
+    ],
+    "GAME-RFC-005-02": [
+      "ARCH-RFC-005"
+    ],
+    "GAME-RFC-006-01": [
+      "ARCH-RFC-006"
+    ],
+    "GAME-RFC-006-02": [
+      "ARCH-RFC-006"
+    ],
+    "GAME-RFC-007-01": [
+      "ARCH-RFC-007"
+    ],
+    "GAME-RFC-007-02": [
+      "ARCH-RFC-007"
+    ],
+    "GAME-RFC-008-01": [
+      "ARCH-RFC-008"
+    ],
+    "GAME-RFC-008-02": [
+      "ARCH-RFC-008"
+    ],
+    "GAME-RFC-009-01": [
+      "ARCH-RFC-009"
+    ],
+    "GAME-RFC-009-02": [
+      "ARCH-RFC-009"
+    ],
+    "GAME-RFC-009-03": [
+      "ARCH-RFC-009"
+    ],
+    "GAME-RFC-010-01": [
+      "ARCH-RFC-010"
+    ],
+    "GAME-RFC-010-02": [
+      "ARCH-RFC-010"
+    ],
+    "GAME-RFC-010-03": [
+      "ARCH-RFC-010"
+    ],
+    "GAME-RFC-010-04": [
+      "ARCH-RFC-010"
+    ],
+    "GAME-RFC-011-01": [
+      "ARCH-RFC-011"
+    ],
+    "GAME-RFC-011-02": [
+      "ARCH-RFC-011"
+    ],
+    "GAME-RFC-012-01": [
+      "ARCH-RFC-012"
+    ],
+    "GAME-RFC-012-02": [
+      "ARCH-RFC-012"
+    ],
+    "GAME-RFC-013-01": [
+      "ARCH-RFC-013"
+    ],
+    "GAME-RFC-013-02": [
+      "ARCH-RFC-013"
+    ],
+    "GAME-RFC-014-01": [
+      "ARCH-RFC-014"
+    ],
+    "GAME-RFC-014-02": [
+      "ARCH-RFC-014"
+    ]
+  }
+}

--- a/docs/status/rfc-dependency-freeze.md
+++ b/docs/status/rfc-dependency-freeze.md
@@ -1,0 +1,27 @@
+# RFC Dependency Freeze – 2025-09-21
+
+## Assignment Guard
+- `assign-copilot-to-issue` workflow now skips when repository variable `COPILOT_ASSIGN_DISABLED` is set to `1`.
+- Set that variable to pause new Copilot handoffs while dependency sequencing is defined.
+
+## Current Queue Snapshot
+(Generated via `gh issue list --state open`; bold items are currently assigned to Copilot.)
+
+- GAME-RFC-014: **014-01** (#359), 014-02 (#360)
+- GAME-RFC-013: **013-01** (#357), 013-02 (#358)
+- GAME-RFC-012: **012-01** (#355), 012-02 (#356)
+- GAME-RFC-011: **011-01** (#353), 011-02 (#354)
+- GAME-RFC-010: **010-01** (#349), 010-02 (#350), 010-03 (#351), 010-04 (#352)
+- GAME-RFC-009: **009-01** (#346), 009-02 (#347), 009-03 (#348)
+- GAME-RFC-008: **008-01** (#344), 008-02 (#345)
+- GAME-RFC-007: **007-01** (#342), 007-02 (#343)
+- GAME-RFC-006: **006-01** (#340), 006-02 (#341)
+- GAME-RFC-005: **005-01** (#338), 005-02 (#339)
+- GAME-RFC-004: **004-01** (#335), 004-02 (#336), 004-03 (#337)
+- GAME-RFC-003: **003-01** (#332), 003-02 (#333), 003-03 (#334)
+- GAME-RFC-002: 002-03 (#331)
+
+## Next Steps
+1. Capture dependency metadata per micro RFC (e.g., add `DependsOn` in Notion).
+2. Extend micro-issue generation and the mutex to respect cross-series dependencies before promoting queued work.
+3. Re-enable assignments once dependency checks are in place.

--- a/scripts/python/production/export_rfc_page_metadata.py
+++ b/scripts/python/production/export_rfc_page_metadata.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Export Notion RFC page metadata for dependency planning."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from generate_micro_issues_from_rfc import get_notion_client
+from notion_page_discovery import NotionPageDiscovery
+
+
+def extract_series_from_title(title: str) -> Optional[str]:
+    match = re.search(r"(?:Game|Architecture)[-\s]?RFC[-\s]?(\d{3})", title, re.IGNORECASE)
+    if match:
+        return f"RFC-{int(match.group(1)):03d}"
+    return None
+
+
+def extract_micro_identifier(title: str) -> Optional[str]:
+    match = re.match(r"Game[-\s]?RFC[-\s]?(\d{3})[-\s]?(\d{2})", title, re.IGNORECASE)
+    if match:
+        return f"GAME-RFC-{int(match.group(1)):03d}-{int(match.group(2)):02d}"
+    return None
+
+
+def fetch_title(discovery: NotionPageDiscovery, page_id: str) -> str:
+    try:
+        page_info = discovery.notion.get_page(page_id)
+        return discovery._extract_title_from_page(page_info)
+    except Exception:
+        return page_id
+
+
+def build_metadata(architecture_id: str, implementation_id: str) -> Dict[str, Any]:
+    client = get_notion_client()
+    discovery = NotionPageDiscovery(client)
+
+    architecture_pages: List[Dict[str, Any]] = []
+    for page in discovery.get_child_pages(architecture_id):
+        title = page.get("title") or fetch_title(discovery, page["id"])
+        series = extract_series_from_title(title)
+        architecture_pages.append(
+            {
+                "id": page["id"],
+                "title": title,
+                "series": series,
+                "architecture_identifier": f"ARCH-{series}" if series else None,
+            }
+        )
+
+    implementation_pages: List[Dict[str, Any]] = []
+    for page_id in discovery.discover_implementation_pages(implementation_id):
+        title = fetch_title(discovery, page_id)
+        identifier = extract_micro_identifier(title)
+        series = extract_series_from_title(title)
+        implementation_pages.append(
+            {
+                "id": page_id,
+                "title": title,
+                "identifier": identifier,
+                "series": series,
+            }
+        )
+
+    # Build default dependency map (implementation -> matching architecture series)
+    series_to_arch = {entry["series"]: entry for entry in architecture_pages if entry.get("series")}
+    dependencies: Dict[str, List[str]] = {}
+    for impl in implementation_pages:
+        ident = impl.get("identifier")
+        series = impl.get("series")
+        if not ident or not series:
+            continue
+        arch_entry = series_to_arch.get(series)
+        if arch_entry and arch_entry.get("architecture_identifier"):
+            dependencies[ident] = [arch_entry["architecture_identifier"]]
+
+    return {
+        "architecture_pages": architecture_pages,
+        "implementation_pages": implementation_pages,
+        "dependencies": dependencies,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export Notion RFC metadata")
+    parser.add_argument("--architecture-collection", required=True, help="Notion page ID for architecture RFCs root")
+    parser.add_argument(
+        "--implementation-collection", required=True, help="Notion page ID for implementation RFCs root"
+    )
+    parser.add_argument("--output", default="notion_rfc_pages.json", help="Path to write JSON output")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    metadata = build_metadata(args.architecture_collection, args.implementation_collection)
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(metadata, fh, indent=2)
+    print(json.dumps(metadata, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- gate `assign-copilot-to-issue` behind repo variable `COPILOT_ASSIGN_DISABLED`
- document current series queue in `docs/status/rfc-dependency-freeze.md`
- add utilities to export Notion RFC metadata and seed a dependency map (`docs/status/rfc-dependencies.json`)

## Testing
- Not applicable (documentation and workflow guard)
