### PR TITLE
feat(flow): enforce RFC dependency ordering

### DIFF
--- a/docs/status/rfc-dependencies.json
+++ b/docs/status/rfc-dependencies.json
@@ -1,46 +1,87 @@
 {
   "architecture": {
+    "ARCH-RFC-001": {
+      "title": "RFC-001: GameConsole 4-Tier Service Architecture",
+      "page_id": "2722b68a-e800-81ff-aae5-d234517d233e"
+    },
     "ARCH-RFC-002": {
-      "title": "Architecture RFC 002"
+      "title": "RFC-002: Category-Based Service Organization",
+      "page_id": "2722b68a-e800-819b-93a9-fa6be418a000"
     },
     "ARCH-RFC-003": {
-      "title": "Architecture RFC 003"
+      "title": "RFC-003: Hierarchical Dependency Injection with Pure.DI",
+      "page_id": "2722b68a-e800-81d4-a99b-d814033a19f4"
     },
     "ARCH-RFC-004": {
-      "title": "Architecture RFC 004"
+      "title": "RFC-004: Plugin-Centric Architecture",
+      "page_id": "2722b68a-e800-810d-93b9-d82e3701f519"
     },
     "ARCH-RFC-005": {
-      "title": "Architecture RFC 005"
+      "title": "RFC-005: Service Provider Pattern",
+      "page_id": "2722b68a-e800-813b-9b4a-ec127e7cc41b"
     },
     "ARCH-RFC-006": {
-      "title": "Architecture RFC 006"
+      "title": "RFC-006: Plugin Management Service",
+      "page_id": "2722b68a-e800-816c-9e97-cbe8e03ceae5"
     },
     "ARCH-RFC-007": {
-      "title": "Architecture RFC 007"
+      "title": "RFC-007: AI Agent Integration",
+      "page_id": "2722b68a-e800-81ad-8589-ec3c2b816f16"
     },
     "ARCH-RFC-008": {
-      "title": "Architecture RFC 008"
+      "title": "RFC-008: Local vs Remote AI Deployment Strategy",
+      "page_id": "2722b68a-e800-81b6-b92a-ee7c01f34432"
     },
     "ARCH-RFC-009": {
-      "title": "Architecture RFC 009"
+      "title": "RFC-009: Akka.NET AI Orchestration",
+      "page_id": "2722b68a-e800-819c-9fa1-c55d7521f4d5"
     },
     "ARCH-RFC-010": {
-      "title": "Architecture RFC 010"
+      "title": "RFC-010: Multi-Modal UI System",
+      "page_id": "2722b68a-e800-8112-8078-f49a01e54cb1"
     },
     "ARCH-RFC-011": {
-      "title": "Architecture RFC 011"
+      "title": "RFC-011: Mode-Based UI Profiles",
+      "page_id": "2722b68a-e800-81ab-9a0c-ce02b936f24f"
     },
     "ARCH-RFC-012": {
-      "title": "Architecture RFC 012"
+      "title": "RFC-012: Container-Native Deployment",
+      "page_id": "2722b68a-e800-8144-b716-e15f6591a119"
     },
     "ARCH-RFC-013": {
-      "title": "Architecture RFC 013"
+      "title": "RFC-013: Configuration Management",
+      "page_id": "2722b68a-e800-8122-80b4-f449899772a2"
     },
     "ARCH-RFC-014": {
-      "title": "Architecture RFC 014"
+      "title": "RFC-014: ECS Behavior Composition",
+      "page_id": "2722b68a-e800-811b-bb14-c7b24a264431"
     }
   },
   "dependencies": {
+    "GAME-RFC-001-01": [
+      "ARCH-RFC-001"
+    ],
+    "GAME-RFC-001-02": [
+      "ARCH-RFC-001"
+    ],
+    "GAME-RFC-001-03": [
+      "ARCH-RFC-001"
+    ],
+    "GAME-RFC-001-04": [
+      "ARCH-RFC-001"
+    ],
+    "GAME-RFC-001-05": [
+      "ARCH-RFC-001"
+    ],
+    "GAME-RFC-001-06": [
+      "ARCH-RFC-001"
+    ],
+    "GAME-RFC-002-01": [
+      "ARCH-RFC-002"
+    ],
+    "GAME-RFC-002-02": [
+      "ARCH-RFC-002"
+    ],
     "GAME-RFC-002-03": [
       "ARCH-RFC-002"
     ],

--- a/scripts/python/production/export_rfc_page_metadata.py
+++ b/scripts/python/production/export_rfc_page_metadata.py
@@ -13,6 +13,8 @@ from notion_page_discovery import NotionPageDiscovery
 
 def extract_series_from_title(title: str) -> Optional[str]:
     match = re.search(r"(?:Game|Architecture)[-\s]?RFC[-\s]?(\d{3})", title, re.IGNORECASE)
+    if not match:
+        match = re.search(r"RFC[-\s]?(\d{3})", title, re.IGNORECASE)
     if match:
         return f"RFC-{int(match.group(1)):03d}"
     return None


### PR DESCRIPTION
## Summary
- extend `generate_micro_issues_from_rfc.py` to load `docs/status/rfc-dependencies.json` and skip Notion-generated issues whose dependencies still have open issues
- add helper tooling for dependency lookups (`load_architecture_titles`, smart search tokens) so architecture RFCs block their implementation children until closed
- update `rfc_assignment_mutex.py` to re-queue candidates when dependencies are unmet, preventing promotion within a series
- refresh the dependency export workflow to capture architecture metadata and regenerate `rfc-dependencies.json`

## Testing
- python -m pytest scripts/python/tests/automation/test_assignment_mutex.py scripts/python/tests/automation/test_orchestrator_cli.py scripts/python/tests/automation/test_chain_consistency.py scripts/python/tests/automation/test_event_bus.py -v
