### PR TITLE
chore(workflow): bump actions/download-artifact to v5

### DIFF
--- a/.github/workflows/rfc-automation.yml
+++ b/.github/workflows/rfc-automation.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: '3.11'
 
       - name: Download previous tracking database
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: rfc-tracking-db
           path: .


### PR DESCRIPTION
Manual replacement for Dependabot PR #387 (permission blocked). This updates .github/workflows/rfc-automation.yml to use actions/download-artifact@v5. Supersedes #387.